### PR TITLE
Updated translation for descending sort for swedish in grid

### DIFF
--- a/messages/grid/grid.sv-SE.yml
+++ b/messages/grid/grid.sv-SE.yml
@@ -130,7 +130,7 @@ kendo:
     sortAscending: Sortera Stigande
 
     # The text shown in the column menu for the sort descending item
-    sortDescending: Sortera Sjunkande
+    sortDescending: Sortera Fallande
 
     # The text shown in the column menu or column chooser for the columns apply button
     columnsApply: Tillämpa


### PR DESCRIPTION
The previous translation was technically correct, but using "Fallande" (literally falling) is the established term. Sorry for missing that in the previous pull request.