### PR TITLE
chore: git is up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ notifications:
   email: false
 node_js:
   - '8'
-addons:
-  apt:
-    sources:
-      - git-core
-    packages:
-      - git
 script:
   - npm run lint
   - git fetch --unshallow origin || true


### PR DESCRIPTION
No need to pull APT packages as Git is already at 2.x