### PR TITLE
 fix: unable to translate messages in workspace projects 

### DIFF
--- a/bin/kendo-translate.js
+++ b/bin/kendo-translate.js
@@ -43,7 +43,7 @@ const args = (() => {
 
 const msgRoot = path.resolve(__dirname, '../messages');
 
-const langFiles = `**/*.${args.locale}.yml`;
+const langFiles = `/**/*.${args.locale}.yml`;
 
 const extendAll = R.reduce(R.mergeWith(R.merge), {});
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "cheerio": "^0.22.0",
     "data.task": "^3.1.1",
-    "glob": "7.1.1",
+    "glob": "^7.1.1",
     "js-yaml": "^3.7.0",
     "ramda": "^0.23.0",
     "xlf-translate": "^2.0.0"


### PR DESCRIPTION
Message data failed to load when calling from a nested project folder.