### PR TITLE
fix: Finnish translations for DateInput

### DIFF
--- a/messages/calendar/dateinput.bg-BG.yml
+++ b/messages/calendar/dateinput.bg-BG.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Увеличи стойността
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Намали стойността

--- a/messages/calendar/dateinput.cs-CZ.yml
+++ b/messages/calendar/dateinput.cs-CZ.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Zvětšit
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Zmenšit

--- a/messages/calendar/dateinput.da-DK.yml
+++ b/messages/calendar/dateinput.da-DK.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Zvětšit
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Zmenšit

--- a/messages/calendar/dateinput.de-AT.yml
+++ b/messages/calendar/dateinput.de-AT.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Wert erhöhen
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Wert verringern

--- a/messages/calendar/dateinput.de-CH.yml
+++ b/messages/calendar/dateinput.de-CH.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Wert erhöhen
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Wert verringern

--- a/messages/calendar/dateinput.de-DE.yml
+++ b/messages/calendar/dateinput.de-DE.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Wert erhöhen
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Wert verringern

--- a/messages/calendar/dateinput.de-LI.yml
+++ b/messages/calendar/dateinput.de-LI.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Wert erhöhen
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Wert verringern

--- a/messages/calendar/dateinput.en-AU.yml
+++ b/messages/calendar/dateinput.en-AU.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Increase value
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Decrease value

--- a/messages/calendar/dateinput.en-CA.yml
+++ b/messages/calendar/dateinput.en-CA.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Increase value
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Decrease value

--- a/messages/calendar/dateinput.en-GB.yml
+++ b/messages/calendar/dateinput.en-GB.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Increase value
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Decrease value

--- a/messages/calendar/dateinput.en-US.yml
+++ b/messages/calendar/dateinput.en-US.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Increase value
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Decrease value

--- a/messages/calendar/dateinput.es-AR.yml
+++ b/messages/calendar/dateinput.es-AR.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-BO.yml
+++ b/messages/calendar/dateinput.es-BO.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-CL.yml
+++ b/messages/calendar/dateinput.es-CL.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-CO.yml
+++ b/messages/calendar/dateinput.es-CO.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-CR.yml
+++ b/messages/calendar/dateinput.es-CR.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-DO.yml
+++ b/messages/calendar/dateinput.es-DO.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-EC.yml
+++ b/messages/calendar/dateinput.es-EC.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-ES.yml
+++ b/messages/calendar/dateinput.es-ES.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-GT.yml
+++ b/messages/calendar/dateinput.es-GT.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-HN.yml
+++ b/messages/calendar/dateinput.es-HN.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-MX.yml
+++ b/messages/calendar/dateinput.es-MX.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-NI.yml
+++ b/messages/calendar/dateinput.es-NI.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-PA.yml
+++ b/messages/calendar/dateinput.es-PA.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-PE.yml
+++ b/messages/calendar/dateinput.es-PE.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-PR.yml
+++ b/messages/calendar/dateinput.es-PR.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-PY.yml
+++ b/messages/calendar/dateinput.es-PY.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-US.yml
+++ b/messages/calendar/dateinput.es-US.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-UY.yml
+++ b/messages/calendar/dateinput.es-UY.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.es-VE.yml
+++ b/messages/calendar/dateinput.es-VE.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Incrementar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Disminuir valor

--- a/messages/calendar/dateinput.fi-FI.yml
+++ b/messages/calendar/dateinput.fi-FI.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Kasvata arvoa
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Vähennä arvoa

--- a/messages/calendar/dateinput.fr-BE.yml
+++ b/messages/calendar/dateinput.fr-BE.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-CA.yml
+++ b/messages/calendar/dateinput.fr-CA.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-CD.yml
+++ b/messages/calendar/dateinput.fr-CD.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-CH.yml
+++ b/messages/calendar/dateinput.fr-CH.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-CI.yml
+++ b/messages/calendar/dateinput.fr-CI.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-CM.yml
+++ b/messages/calendar/dateinput.fr-CM.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-FR.yml
+++ b/messages/calendar/dateinput.fr-FR.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-HT.yml
+++ b/messages/calendar/dateinput.fr-HT.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-LU.yml
+++ b/messages/calendar/dateinput.fr-LU.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-MA.yml
+++ b/messages/calendar/dateinput.fr-MA.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-MC.yml
+++ b/messages/calendar/dateinput.fr-MC.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-ML.yml
+++ b/messages/calendar/dateinput.fr-ML.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.fr-SN.yml
+++ b/messages/calendar/dateinput.fr-SN.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur

--- a/messages/calendar/dateinput.he-IL.yml
+++ b/messages/calendar/dateinput.he-IL.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: למעלה
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: למטה

--- a/messages/calendar/dateinput.hy-AM.yml
+++ b/messages/calendar/dateinput.hy-AM.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: למעלה
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: למטה

--- a/messages/calendar/dateinput.it-CH.yml
+++ b/messages/calendar/dateinput.it-CH.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: למעלה
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: למטה

--- a/messages/calendar/dateinput.it-IT.yml
+++ b/messages/calendar/dateinput.it-IT.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: למעלה
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: למטה

--- a/messages/calendar/dateinput.ja-JP.yml
+++ b/messages/calendar/dateinput.ja-JP.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: 値を増やす
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: 値を減らす

--- a/messages/calendar/dateinput.nb-NO.yml
+++ b/messages/calendar/dateinput.nb-NO.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: 値を増やす
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: 値を減らす

--- a/messages/calendar/dateinput.nl-BE.yml
+++ b/messages/calendar/dateinput.nl-BE.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Verhogen
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Verlagen

--- a/messages/calendar/dateinput.nl-NL.yml
+++ b/messages/calendar/dateinput.nl-NL.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Verhogen
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Verlagen

--- a/messages/calendar/dateinput.pl-PL.yml
+++ b/messages/calendar/dateinput.pl-PL.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: 値を増やす
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: 値を減らす

--- a/messages/calendar/dateinput.pt-BR.yml
+++ b/messages/calendar/dateinput.pt-BR.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Aumentar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuir valor

--- a/messages/calendar/dateinput.pt-PT.yml
+++ b/messages/calendar/dateinput.pt-PT.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Aumentar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuir valor

--- a/messages/calendar/dateinput.ro-RO.yml
+++ b/messages/calendar/dateinput.ro-RO.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Aumentar valor
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Diminuir valor

--- a/messages/calendar/dateinput.ru-RU.yml
+++ b/messages/calendar/dateinput.ru-RU.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Увеличить значение
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Уменьшить значение

--- a/messages/calendar/dateinput.sk-SK.yml
+++ b/messages/calendar/dateinput.sk-SK.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Zvýšiť hodnotu
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Znížiť hodnotu

--- a/messages/calendar/dateinput.sv-SE.yml
+++ b/messages/calendar/dateinput.sv-SE.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Zvýšiť hodnotu
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Znížiť hodnotu

--- a/messages/calendar/dateinput.tr-TR.yml
+++ b/messages/calendar/dateinput.tr-TR.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Zvýšiť hodnotu
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Znížiť hodnotu

--- a/messages/calendar/dateinput.uk-UA.yml
+++ b/messages/calendar/dateinput.uk-UA.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: Zvýšiť hodnotu
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: Znížiť hodnotu

--- a/messages/calendar/dateinput.zh-CN.yml
+++ b/messages/calendar/dateinput.zh-CN.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: 增加
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: 减少

--- a/messages/calendar/dateinput.zh-HK.yml
+++ b/messages/calendar/dateinput.zh-HK.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: 增加
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: 減少

--- a/messages/calendar/dateinput.zh-TW.yml
+++ b/messages/calendar/dateinput.zh-TW.yml
@@ -1,7 +1,0 @@
-kendo:
-  dateinput:
-    # The label for the **Increment** button in the DateInput
-    increment: 增加
-
-    # The label for the **Decrement** button in the DateInput
-    decrement: 減少

--- a/messages/dateinput/dateinput.fi-FI.yml
+++ b/messages/dateinput/dateinput.fi-FI.yml
@@ -1,7 +1,7 @@
 kendo:
   dateinput:
     # The label for the **Increment** button in the DateInput
-    increment: Augmenter la valeur
+    increment: Kasvata arvoa
 
     # The label for the **Decrement** button in the DateInput
-    decrement: Diminuer la valeur
+    decrement: Vähennä arvoa


### PR DESCRIPTION
The DateInput messages were duplicated in the `messages/calendar` folder and were out of sync.

Ref https://github.com/telerik/kendo-angular-messages/issues/85