### PR TITLE
feat: add datetimepicker translations for en/de/es

### DIFF
--- a/messages/datetimepicker/datetimepicker.ar.yml
+++ b/messages/datetimepicker/datetimepicker.ar.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.bg-BG.yml
+++ b/messages/datetimepicker/datetimepicker.bg-BG.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.cs-CZ.yml
+++ b/messages/datetimepicker/datetimepicker.cs-CZ.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.da-DK.yml
+++ b/messages/datetimepicker/datetimepicker.da-DK.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.de-AT.yml
+++ b/messages/datetimepicker/datetimepicker.de-AT.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Datum
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Datum
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Zeit
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Zeit
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Umschalten
+
+    # The Accept button text in the datetimepicker component
+    accept: Setzen
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Setzen
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Abbrechen
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Abbrechen
+
+    # The Now button text in the timepicker component
+    now: JETZT
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Jetzt
+
+    # The label for the today button in the calendar header
+    today: HEUTE

--- a/messages/datetimepicker/datetimepicker.de-CH.yml
+++ b/messages/datetimepicker/datetimepicker.de-CH.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Datum
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Datum
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Zeit
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Zeit
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Umschalten
+
+    # The Accept button text in the datetimepicker component
+    accept: Setzen
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Setzen
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Abbrechen
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Abbrechen
+
+    # The Now button text in the timepicker component
+    now: JETZT
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Jetzt
+
+    # The label for the today button in the calendar header
+    today: HEUTE

--- a/messages/datetimepicker/datetimepicker.de-DE.yml
+++ b/messages/datetimepicker/datetimepicker.de-DE.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Datum
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Datum
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Zeit
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Zeit
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Umschalten
+
+    # The Accept button text in the datetimepicker component
+    accept: Setzen
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Setzen
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Abbrechen
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Abbrechen
+
+    # The Now button text in the timepicker component
+    now: JETZT
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Jetzt
+
+    # The label for the today button in the calendar header
+    today: HEUTE

--- a/messages/datetimepicker/datetimepicker.de-LI.yml
+++ b/messages/datetimepicker/datetimepicker.de-LI.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Datum
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Datum
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Zeit
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Zeit
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Umschalten
+
+    # The Accept button text in the datetimepicker component
+    accept: Setzen
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Setzen
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Abbrechen
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Abbrechen
+
+    # The Now button text in the timepicker component
+    now: JETZT
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Jetzt
+
+    # The label for the today button in the calendar header
+    today: HEUTE

--- a/messages/datetimepicker/datetimepicker.en-AU.yml
+++ b/messages/datetimepicker/datetimepicker.en-AU.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.en-CA.yml
+++ b/messages/datetimepicker/datetimepicker.en-CA.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.en-GB.yml
+++ b/messages/datetimepicker/datetimepicker.en-GB.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.en-US.yml
+++ b/messages/datetimepicker/datetimepicker.en-US.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.es-AR.yml
+++ b/messages/datetimepicker/datetimepicker.es-AR.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-BO.yml
+++ b/messages/datetimepicker/datetimepicker.es-BO.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-CL.yml
+++ b/messages/datetimepicker/datetimepicker.es-CL.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-CO.yml
+++ b/messages/datetimepicker/datetimepicker.es-CO.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-CR.yml
+++ b/messages/datetimepicker/datetimepicker.es-CR.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-DO.yml
+++ b/messages/datetimepicker/datetimepicker.es-DO.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-EC.yml
+++ b/messages/datetimepicker/datetimepicker.es-EC.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-ES.yml
+++ b/messages/datetimepicker/datetimepicker.es-ES.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-GT.yml
+++ b/messages/datetimepicker/datetimepicker.es-GT.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-HN.yml
+++ b/messages/datetimepicker/datetimepicker.es-HN.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-MX.yml
+++ b/messages/datetimepicker/datetimepicker.es-MX.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-NI.yml
+++ b/messages/datetimepicker/datetimepicker.es-NI.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-PA.yml
+++ b/messages/datetimepicker/datetimepicker.es-PA.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-PE.yml
+++ b/messages/datetimepicker/datetimepicker.es-PE.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-PR.yml
+++ b/messages/datetimepicker/datetimepicker.es-PR.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-PY.yml
+++ b/messages/datetimepicker/datetimepicker.es-PY.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-US.yml
+++ b/messages/datetimepicker/datetimepicker.es-US.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-UY.yml
+++ b/messages/datetimepicker/datetimepicker.es-UY.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.es-VE.yml
+++ b/messages/datetimepicker/datetimepicker.es-VE.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Fecha
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Mostrar fecha
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Hora
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Mostrar hora
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Cambiar calendario
+
+    # The Accept button text in the datetimepicker component
+    accept: Acceptar
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Acceptar
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancelar
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancelar
+
+    # The Now button text in the timepicker component
+    now: AHORA
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Ahora
+
+    # The label for the today button in the calendar header
+    today: HOY

--- a/messages/datetimepicker/datetimepicker.fi-FI.yml
+++ b/messages/datetimepicker/datetimepicker.fi-FI.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-BE.yml
+++ b/messages/datetimepicker/datetimepicker.fr-BE.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-CA.yml
+++ b/messages/datetimepicker/datetimepicker.fr-CA.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-CD.yml
+++ b/messages/datetimepicker/datetimepicker.fr-CD.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-CH.yml
+++ b/messages/datetimepicker/datetimepicker.fr-CH.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-CI.yml
+++ b/messages/datetimepicker/datetimepicker.fr-CI.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-CM.yml
+++ b/messages/datetimepicker/datetimepicker.fr-CM.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-FR.yml
+++ b/messages/datetimepicker/datetimepicker.fr-FR.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-HT.yml
+++ b/messages/datetimepicker/datetimepicker.fr-HT.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-LU.yml
+++ b/messages/datetimepicker/datetimepicker.fr-LU.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-MA.yml
+++ b/messages/datetimepicker/datetimepicker.fr-MA.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-MC.yml
+++ b/messages/datetimepicker/datetimepicker.fr-MC.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-ML.yml
+++ b/messages/datetimepicker/datetimepicker.fr-ML.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.fr-SN.yml
+++ b/messages/datetimepicker/datetimepicker.fr-SN.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.he-IL.yml
+++ b/messages/datetimepicker/datetimepicker.he-IL.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.hy-AM.yml
+++ b/messages/datetimepicker/datetimepicker.hy-AM.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.it-CH.yml
+++ b/messages/datetimepicker/datetimepicker.it-CH.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.it-IT.yml
+++ b/messages/datetimepicker/datetimepicker.it-IT.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.ja-JP.yml
+++ b/messages/datetimepicker/datetimepicker.ja-JP.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.nb-NO.yml
+++ b/messages/datetimepicker/datetimepicker.nb-NO.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.nl-BE.yml
+++ b/messages/datetimepicker/datetimepicker.nl-BE.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.nl-NL.yml
+++ b/messages/datetimepicker/datetimepicker.nl-NL.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.pl-PL.yml
+++ b/messages/datetimepicker/datetimepicker.pl-PL.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.pt-BR.yml
+++ b/messages/datetimepicker/datetimepicker.pt-BR.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.pt-PT.yml
+++ b/messages/datetimepicker/datetimepicker.pt-PT.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.ro-RO.yml
+++ b/messages/datetimepicker/datetimepicker.ro-RO.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.ru-RU.yml
+++ b/messages/datetimepicker/datetimepicker.ru-RU.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.sk-SK.yml
+++ b/messages/datetimepicker/datetimepicker.sk-SK.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.sv-SE.yml
+++ b/messages/datetimepicker/datetimepicker.sv-SE.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.tr-TR.yml
+++ b/messages/datetimepicker/datetimepicker.tr-TR.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.uk-UA.yml
+++ b/messages/datetimepicker/datetimepicker.uk-UA.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.zh-CN.yml
+++ b/messages/datetimepicker/datetimepicker.zh-CN.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.zh-HK.yml
+++ b/messages/datetimepicker/datetimepicker.zh-HK.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY

--- a/messages/datetimepicker/datetimepicker.zh-TW.yml
+++ b/messages/datetimepicker/datetimepicker.zh-TW.yml
@@ -1,0 +1,37 @@
+kendo:
+  datetimepicker:
+    # The Date tab text in the datetimepicker popup header
+    dateTab: Date
+
+    # The label for the Date tab in the datetimepicker popup header
+    dateTabLabel: Date tab
+
+    # The Time tab text in the datetimepicker popup header
+    timeTab: Time
+
+    # The label for the Time tab in the datetimepicker popup header
+    timeTabLabel: Time tab
+
+    # The label for the toggle button in the datetimepicker component
+    toggle: Toggle popup
+
+    # The Accept button text in the datetimepicker component
+    accept: Set
+
+    # The label for the Accept button in the datetimepicker component
+    acceptLabel: Set
+
+    # The Cancel button text in the datetimepicker component
+    cancel: Cancel
+
+    # The label for the Cancel button in the datetimepicker component
+    cancelLabel: Cancel
+
+    # The Now button text in the timepicker component
+    now: NOW
+
+    # The label for the Now button in the timepicker component
+    nowLabel: Select now
+
+    # The label for the today button in the calendar header
+    today: TODAY


### PR DESCRIPTION
related to [dateinputs#303](https://github.com/telerik/kendo-angular-dateinputs/pull/303)

* added the default English labels, as well as translations for German and Spanish (used the same translations for all `de-` and `es-` locales);
* also included in the commit are files for other cultures with the default English labels; used as source files the ones included for the **DatePicker**;