### PR TITLE
feat: add treelist messages

### DIFF
--- a/messages/treelist/treelist.ar.yml
+++ b/messages/treelist/treelist.ar.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: اسحب رأس عمود واسقطه هنا لتجميعه بهذا العمود
+
+    # The label visible in the Grid when there are no records
+    noRecords: لا توجد عناصر متاحة
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: انتقل إلى الصفحة الأولى
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: انتقل إلى الصفحة السابقة
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: انتقل إلى الصفحة التالية
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: انتقل إلى الصفحة الأخيرة
+
+    # The label before the current page number in the Grid pager
+    pagerPage: الصفحة
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: من
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: العناصر
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: العناصر لكل صفحة
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: يساوي
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: لا يساوي
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Is null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: غير فارغ
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: فارغ
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: غير فارغ
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: يبدأ ب 
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: يحتوى
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: لا يحتوي
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: ينتهي ب
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: أكبر من أو يساوي
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: أكبر من
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: أقل من أو يساوي
+
+    # The text of the "less than" filter operator
+    filterLtOperator: أقل من أو يساوي
+
+    # The text of the "Is true" filter option
+    filterIsTrue: صحيح
+
+    # The text of the "Is false" filter option
+    filterIsFalse: غير صحيح
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (الكل)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: هو بعد أو يساوي
+
+    # The text of the after date filter operator
+    filterAfterOperator: هو بعد
+
+    # The text of the before date filter operator
+    filterBeforeOperator: قبل ذلك
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: هو قبل أو يساوي
+
+    # The text of the "filter button"
+    filterFilterButton: Filter
+
+    # The text of the "clear filter button"
+    filterClearButton: Clear
+
+    # The text of the "And" filter logic
+    filterAndLogic: And
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Or
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.bg-BG.yml
+++ b/messages/treelist/treelist.bg-BG.yml
@@ -1,0 +1,153 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Дръпни колона и я пусни тук, за да групираш
+
+    # The label visible in the Grid when there are no records
+    noRecords: Няма налични записи.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Към първата страница
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Към предишната страница
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Към следващата страница
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Към последната страница
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Страница
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: от
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: записа
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: записи на страница
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Е равно на
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Не е равно на
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Е null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Не е null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Е празно
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: Не е празно
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Започва с
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Съдържа
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Не съдържа
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Завършва на
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Е по-голяма или равно на
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Е по-голямо от
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Е по-малко или равно на
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Е по-малко от
+
+    # The text of the "Is true" filter option
+    filterIsTrue: е вярно
+
+    # The text of the "Is false" filter option
+    filterIsFalse: не е вярно
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Всички)
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Е след или равно на
+
+    # The text of the after date filter operator
+    filterAfterOperator: Е след
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Е преди
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Е преди или равно на
+
+    # The text of the "filter button"
+    filterFilterButton: Филтрирай
+
+    # The text of the "clear filter button"
+    filterClearButton: Премахни филтър
+
+    # The text of the "And" filter logic
+    filterAndLogic: и
+
+    # The text of the "Or" filter logic
+    filterOrLogic: или
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.cs-CZ.yml
+++ b/messages/treelist/treelist.cs-CZ.yml
@@ -1,0 +1,153 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Přetáhněte sem záhlaví sloupce pro seskupení dle vybraného sloupce.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Žádný záznam nenalezen.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Na první stránku
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Na předchozí stránku
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Na další stránku
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Na poslední stránku
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Strana
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: z
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: záznamů
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: záznamů na stránku
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Je shodná s
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Je různá od
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Není null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: je prázdný
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: není prázdný
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Začíná na
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Obsahuje
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Neobsahuje
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Končí na
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Je větší nebo rovno
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Je větší než
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Je menší nebo rovno
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Je menší nebo rovno
+
+    # The text of the "Is true" filter option
+    filterIsTrue: je pravda
+
+    # The text of the "Is false" filter option
+    filterIsFalse: není pravda
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Všechno)
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Začíná od
+
+    # The text of the after date filter operator
+    filterAfterOperator: Začíná po
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Končí po
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Končí do
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrovat
+
+    # The text of the "clear filter button"
+    filterClearButton: Zrušit
+
+    # The text of the "And" filter logic
+    filterAndLogic: A zároveň
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Nebo
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.da-DK.yml
+++ b/messages/treelist/treelist.da-DK.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Træk en kolonneoverskrift herover for at gruppére på den kolonne
+
+    # The label visible in the Grid when there are no records
+    noRecords: Ingen optegnelser til rådighed.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Gå til første side
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Gå til forrige side
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Gå til næste side
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Gå til sidste side
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Side
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: af
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: emner
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: emner pr side
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Er lig med
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Er forskellig fra
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: er null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: er ikke null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: er tom
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: er ikke tom
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Begynder med
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Indeholder
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ikke indeholder
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Slutter med
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Er større end eller lig med
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Er større end
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Er mindre end eller lig med
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Er mindre end eller lig med
+
+    # The text of the "Is true" filter option
+    filterIsTrue: er sandt
+
+    # The text of the "Is false" filter option
+    filterIsFalse: er falskt
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Alle)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Er senere end eller lig med
+
+    # The text of the after date filter operator
+    filterAfterOperator: Er senere end
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Er før
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Er før eller lig med
+
+    # The text of the "filter button"
+    filterFilterButton: Filter
+
+    # The text of the "clear filter button"
+    filterClearButton: Nulstil
+
+    # The text of the "And" filter logic
+    filterAndLogic: Og
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Eller
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.de-AT.yml
+++ b/messages/treelist/treelist.de-AT.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Ziehen Sie eine Spaltenüberschrift hierher, um nach dieser Spalte zu gruppieren
+
+    # The label visible in the Grid when there are no records
+    noRecords: Keine Datensätze verfügbar.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Zur ersten Seite
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Zur vorherigen Seite
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Zur nächsten Seite
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Zur letzten Seite
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Seite
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: von
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: Elementen
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: Elemente pro Seite
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: ist gleich
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: ist nicht gleich
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: ist Null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: ist nicht Null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: ist leer
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: ist nicht leer
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: beginnt mit
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: beinhaltet
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: beinhaltet nicht
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: endet mit
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: ist größer als oder gleich
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: ist größer als
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: ist kleiner oder gleich als
+
+    # The text of the "less than" filter operator
+    filterLtOperator: ist kleiner als
+
+    # The text of the "Is true" filter option
+    filterIsTrue: ist richtig
+
+    # The text of the "Is false" filter option
+    filterIsFalse: ist falsch
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Alle)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: ist gleich oder später als
+
+    # The text of the after date filter operator
+    filterAfterOperator: ist später als
+
+    # The text of the before date filter operator
+    filterBeforeOperator: ist früher als
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: ist gleich oder früher als
+
+    # The text of the "filter button"
+    filterFilterButton: Filtern
+
+    # The text of the "clear filter button"
+    filterClearButton: Löschen
+
+    # The text of the "And" filter logic
+    filterAndLogic: und
+
+    # The text of the "Or" filter logic
+    filterOrLogic: oder
+
+    # The loading text
+    loading: Laden
+
+    # The label of the sort icon
+    sort: Sortieren
+
+    # The title of the column menu icon
+    columnMenu: Spaltenmenü
+
+    # The text shown in the column menu for the columns item
+    columns: Spalten
+
+    # The text shown in the column menu for the lock item
+    lock: Sperren
+
+    # The text shown in the column menu for the unlock item
+    unlock: Entsperren
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Aufsteigend sortieren
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Absteigend sortieren
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Übernehmen
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Zurücksetzen
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.de-CH.yml
+++ b/messages/treelist/treelist.de-CH.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Ziehen Sie eine Spaltenüberschrift hierher, um nach dieser Spalte zu gruppieren
+
+    # The label visible in the Grid when there are no records
+    noRecords: Keine Datensätze verfügbar.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Zur ersten Seite
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Zur vorherigen Seite
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Zur nächsten Seite
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Zur letzten Seite
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Seite
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: von
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: Elementen
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: Elemente pro Seite
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: ist gleich
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: ist nicht gleich
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: ist Null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: ist nicht Null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: ist leer
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: ist nicht leer
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: beginnt mit
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: beinhaltet
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: beinhaltet nicht
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: endet mit
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: ist größer als oder gleich
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: ist größer als
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: ist kleiner oder gleich als
+
+    # The text of the "less than" filter operator
+    filterLtOperator: ist kleiner als
+
+    # The text of the "Is true" filter option
+    filterIsTrue: ist richtig
+
+    # The text of the "Is false" filter option
+    filterIsFalse: ist falsch
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Alle)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: ist gleich oder später als
+
+    # The text of the after date filter operator
+    filterAfterOperator: ist später als
+
+    # The text of the before date filter operator
+    filterBeforeOperator: ist früher als
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: ist gleich oder früher als
+
+    # The text of the "filter button"
+    filterFilterButton: Filtern
+
+    # The text of the "clear filter button"
+    filterClearButton: Löschen
+
+    # The text of the "And" filter logic
+    filterAndLogic: und
+
+    # The text of the "Or" filter logic
+    filterOrLogic: oder
+
+    # The loading text
+    loading: Laden
+
+    # The label of the sort icon
+    sort: Sortieren
+
+    # The title of the column menu icon
+    columnMenu: Spaltenmenü
+
+    # The text shown in the column menu for the columns item
+    columns: Spalten
+
+    # The text shown in the column menu for the lock item
+    lock: Sperren
+
+    # The text shown in the column menu for the unlock item
+    unlock: Entsperren
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Aufsteigend sortieren
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Absteigend sortieren
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Übernehmen
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Zurücksetzen
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.de-DE.yml
+++ b/messages/treelist/treelist.de-DE.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Ziehen Sie eine Spaltenüberschrift hierher, um nach dieser Spalte zu gruppieren
+
+    # The label visible in the Grid when there are no records
+    noRecords: Keine Datensätze verfügbar.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Zur ersten Seite
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Zur vorherigen Seite
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Zur nächsten Seite
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Zur letzten Seite
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Seite
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: von
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: Elemente
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: Elemente pro Seite
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: ist gleich
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: ist nicht gleich
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: ist Null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: ist nicht Null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: ist leer
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: ist nicht leer
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: beginnt mit
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: beinhaltet
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: beinhaltet nicht
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: endet mit
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: ist größer als oder gleich
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: ist größer als
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: ist kleiner oder gleich als
+
+    # The text of the "less than" filter operator
+    filterLtOperator: ist kleiner als
+
+    # The text of the "Is true" filter option
+    filterIsTrue: ist richtig
+
+    # The text of the "Is false" filter option
+    filterIsFalse: ist falsch
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Alle)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: ist gleich oder später als
+
+    # The text of the after date filter operator
+    filterAfterOperator: ist später als
+
+    # The text of the before date filter operator
+    filterBeforeOperator: ist früher als
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: ist gleich oder früher als
+
+    # The text of the "filter button"
+    filterFilterButton: Filtern
+
+    # The text of the "clear filter button"
+    filterClearButton: Löschen
+
+    # The text of the "And" filter logic
+    filterAndLogic: und
+
+    # The text of the "Or" filter logic
+    filterOrLogic: oder
+
+    # The loading text
+    loading: Laden
+
+    # The label of the sort icon
+    sort: Sortieren
+
+    # The title of the column menu icon
+    columnMenu: Spaltenmenü
+
+    # The text shown in the column menu for the columns item
+    columns: Spalten
+
+    # The text shown in the column menu for the lock item
+    lock: Sperren
+
+    # The text shown in the column menu for the unlock item
+    unlock: Entsperren
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Aufsteigend sortieren
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Absteigend sortieren
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Übernehmen
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Zurücksetzen
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.de-LI.yml
+++ b/messages/treelist/treelist.de-LI.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Ziehen Sie eine Spaltenüberschrift hierher, um nach dieser Spalte zu gruppieren
+
+    # The label visible in the Grid when there are no records
+    noRecords: Keine Datensätze verfügbar.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Zur ersten Seite
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Zur vorherigen Seite
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Zur nächsten Seite
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Zur letzten Seite
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Seite
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: von
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: Elementen
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: Elemente pro Seite
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: ist gleich
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: ist nicht gleich
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: ist Null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: ist nicht Null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: ist leer
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: ist nicht leer
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: beginnt mit
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: beinhaltet
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: beinhaltet nicht
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: endet mit
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: ist größer als oder gleich
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: ist größer als
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: ist kleiner oder gleich als
+
+    # The text of the "less than" filter operator
+    filterLtOperator: ist kleiner als
+
+    # The text of the "Is true" filter option
+    filterIsTrue: ist richtig
+
+    # The text of the "Is false" filter option
+    filterIsFalse: ist falsch
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Alle)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: ist gleich oder später als
+
+    # The text of the after date filter operator
+    filterAfterOperator: ist später als
+
+    # The text of the before date filter operator
+    filterBeforeOperator: ist früher als
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: ist gleich oder früher als
+
+    # The text of the "filter button"
+    filterFilterButton: Filtern
+
+    # The text of the "clear filter button"
+    filterClearButton: Löschen
+
+    # The text of the "And" filter logic
+    filterAndLogic: und
+
+    # The text of the "Or" filter logic
+    filterOrLogic: oder
+
+    # The loading text
+    loading: Laden
+
+    # The label of the sort icon
+    sort: Sortieren
+
+    # The title of the column menu icon
+    columnMenu: Spaltenmenü
+
+    # The text shown in the column menu for the columns item
+    columns: Spalten
+
+    # The text shown in the column menu for the lock item
+    lock: Sperren
+
+    # The text shown in the column menu for the unlock item
+    unlock: Entsperren
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Aufsteigend sortieren
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Absteigend sortieren
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Übernehmen
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Zurücksetzen
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.en-AU.yml
+++ b/messages/treelist/treelist.en-AU.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Drag a column header and drop it here to group by that column
+
+    # The label visible in the Grid when there are no records
+    noRecords: No records available.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Go to the first page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Go to the previous page
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Go to the next page
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Go to the last page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: of
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: items
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: items per page
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Is equal to
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Is not equal to
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Is null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Is not null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Is empty
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: Is not empty
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Starts with
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contains
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Does not contain
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Ends with
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Is greater than or equal to
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Is greater than
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Is less than or equal to
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Is less than
+
+    # The text of the "Is true" filter option
+    filterIsTrue: is true
+
+    # The text of the "Is false" filter option
+    filterIsFalse: is false
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (All)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Is after or equal to
+
+    # The text of the after date filter operator
+    filterAfterOperator: Is after
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Is before
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Is before or equal to
+
+    # The text of the "filter button"
+    filterFilterButton: Filter
+
+    # The text of the "clear filter button"
+    filterClearButton: Clear
+
+    # The text of the "And" filter logic
+    filterAndLogic: And
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Or
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.en-CA.yml
+++ b/messages/treelist/treelist.en-CA.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Drag a column header and drop it here to group by that column
+
+    # The label visible in the Grid when there are no records
+    noRecords: No records available.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Go to the first page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Go to the previous page
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Go to the next page
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Go to the last page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: of
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: items
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: items per page
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Is equal to
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Is not equal to
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Is null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Is not null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Is empty
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: Is not empty
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Starts with
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contains
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Does not contain
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Ends with
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Is greater than or equal to
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Is greater than
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Is less than or equal to
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Is less than
+
+    # The text of the "Is true" filter option
+    filterIsTrue: is true
+
+    # The text of the "Is false" filter option
+    filterIsFalse: is false
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (All)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Is after or equal to
+
+    # The text of the after date filter operator
+    filterAfterOperator: Is after
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Is before
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Is before or equal to
+
+    # The text of the "filter button"
+    filterFilterButton: Filter
+
+    # The text of the "clear filter button"
+    filterClearButton: Clear
+
+    # The text of the "And" filter logic
+    filterAndLogic: And
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Or
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.en-GB.yml
+++ b/messages/treelist/treelist.en-GB.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Drag a column header and drop it here to group by that column
+
+    # The label visible in the Grid when there are no records
+    noRecords: No records available.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Go to the first page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Go to the previous page
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Go to the next page
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Go to the last page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: of
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: items
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: items per page
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Is equal to
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Is not equal to
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Is null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Is not null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Is empty
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: Is not empty
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Starts with
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contains
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Does not contain
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Ends with
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Is greater than or equal to
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Is greater than
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Is less than or equal to
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Is less than
+
+    # The text of the "Is true" filter option
+    filterIsTrue: is true
+
+    # The text of the "Is false" filter option
+    filterIsFalse: is false
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (All)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Is after or equal to
+
+    # The text of the after date filter operator
+    filterAfterOperator: Is after
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Is before
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Is before or equal to
+
+    # The text of the "filter button"
+    filterFilterButton: Filter
+
+    # The text of the "clear filter button"
+    filterClearButton: Clear
+
+    # The text of the "And" filter logic
+    filterAndLogic: And
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Or
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.en-US.yml
+++ b/messages/treelist/treelist.en-US.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Drag a column header and drop it here to group by that column
+
+    # The label visible in the Grid when there are no records
+    noRecords: No records available.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Go to the first page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Go to the previous page
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Go to the next page
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Go to the last page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: of
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: items total
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: items per page
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Is equal to
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Is not equal to
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Is null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Is not null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Is empty
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: Is not empty
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Starts with
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contains
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Does not contain
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Ends with
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Is greater than or equal to
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Is greater than
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Is less than or equal to
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Is less than
+
+    # The text of the "Is true" filter option
+    filterIsTrue: is true
+
+    # The text of the "Is false" filter option
+    filterIsFalse: is false
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (All)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Is after or equal to
+
+    # The text of the after date filter operator
+    filterAfterOperator: Is after
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Is before
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Is before or equal to
+
+    # The text of the "filter button"
+    filterFilterButton: Filter
+
+    # The text of the "clear filter button"
+    filterClearButton: Clear
+
+    # The text of the "And" filter logic
+    filterAndLogic: And
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Or
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-AR.yml
+++ b/messages/treelist/treelist.es-AR.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todas)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-BO.yml
+++ b/messages/treelist/treelist.es-BO.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todas)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-CL.yml
+++ b/messages/treelist/treelist.es-CL.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todas)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-CO.yml
+++ b/messages/treelist/treelist.es-CO.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todas)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-CR.yml
+++ b/messages/treelist/treelist.es-CR.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todas)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-DO.yml
+++ b/messages/treelist/treelist.es-DO.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todas)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-EC.yml
+++ b/messages/treelist/treelist.es-EC.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todas)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-ES.yml
+++ b/messages/treelist/treelist.es-ES.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todas)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-GT.yml
+++ b/messages/treelist/treelist.es-GT.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-HN.yml
+++ b/messages/treelist/treelist.es-HN.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-MX.yml
+++ b/messages/treelist/treelist.es-MX.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-NI.yml
+++ b/messages/treelist/treelist.es-NI.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-PA.yml
+++ b/messages/treelist/treelist.es-PA.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-PE.yml
+++ b/messages/treelist/treelist.es-PE.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-PR.yml
+++ b/messages/treelist/treelist.es-PR.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-PY.yml
+++ b/messages/treelist/treelist.es-PY.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-US.yml
+++ b/messages/treelist/treelist.es-US.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-UY.yml
+++ b/messages/treelist/treelist.es-UY.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.es-VE.yml
+++ b/messages/treelist/treelist.es-VE.yml
@@ -1,0 +1,150 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arrastre el título de una columna y suéltelo aquí para agrupar por ese criterio
+
+    # The label visible in the Grid when there are no records
+    noRecords: No hay datos disponibles.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir a la primera página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir a la página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir a la página siguiente
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir a la última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: ítems
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: ítems por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Es igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: No es igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Es nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: No es nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Está vacío
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: No está vacío
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Comienza con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: No contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina en
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Es mayor o igual que
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Es mayor que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Es menor o igual que
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Es menor o igual que
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Sí
+
+    # The text of the "Is false" filter option
+    filterIsFalse: No
+
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Es posterior o igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: Es posterior
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Es anterior
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Es anterior o igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpiar filtros
+
+    # The text of the "And" filter logic
+    filterAndLogic: Y
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fi-FI.yml
+++ b/messages/treelist/treelist.fi-FI.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Vedä sarakeotsikko tähän ryhmitelläksesi sarakkeen perusteella
+
+    # The label visible in the Grid when there are no records
+    noRecords: Ei tietueita.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ensimmäinen sivu
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Edellinen sivu
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Seuraava sivu
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Viimeinen sivu
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Sivu
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: of
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: tulosta
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: tulosta sivulla
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: On
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Ei ole
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: on nolla
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: ei ole nolla
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: on tyhjä
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: ei ole tyhjä
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Alkaa
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Sisältää
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ei sisällä
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Loppuu
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: On tasan tai suurempi kuin
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: On suurempi kuin
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: On tasan tai pienempi kuin
+
+    # The text of the "less than" filter operator
+    filterLtOperator: On tasan tai pienempi kuin
+
+    # The text of the "Is true" filter option
+    filterIsTrue: on
+
+    # The text of the "Is false" filter option
+    filterIsFalse: ei ole
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Kaikki)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: On tasan tai myöhempi kuin
+
+    # The text of the after date filter operator
+    filterAfterOperator: On myöhempi kuin
+
+    # The text of the before date filter operator
+    filterBeforeOperator: On aikaisempi kuin
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: On tasan tai aikaisempi kuin
+
+    # The text of the "filter button"
+    filterFilterButton: Suodata
+
+    # The text of the "clear filter button"
+    filterClearButton: Tyhjennä
+
+    # The text of the "And" filter logic
+    filterAndLogic: Ja
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Tai
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-BE.yml
+++ b/messages/treelist/treelist.fr-BE.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-CA.yml
+++ b/messages/treelist/treelist.fr-CA.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-CD.yml
+++ b/messages/treelist/treelist.fr-CD.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-CH.yml
+++ b/messages/treelist/treelist.fr-CH.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-CI.yml
+++ b/messages/treelist/treelist.fr-CI.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-CM.yml
+++ b/messages/treelist/treelist.fr-CM.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-FR.yml
+++ b/messages/treelist/treelist.fr-FR.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-HT.yml
+++ b/messages/treelist/treelist.fr-HT.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-LU.yml
+++ b/messages/treelist/treelist.fr-LU.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-MA.yml
+++ b/messages/treelist/treelist.fr-MA.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-MC.yml
+++ b/messages/treelist/treelist.fr-MC.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-ML.yml
+++ b/messages/treelist/treelist.fr-ML.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.fr-SN.yml
+++ b/messages/treelist/treelist.fr-SN.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Faites glisser un en-tête de colonne et déposer ici pour grouper par cette colonne.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Aucun enregistrement disponible.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Aller à la première page
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Aller à la page précédente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Aller à la page suivante
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Aller à la dernière page
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Page
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: éléments
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: éléments par page
+
+    # The label of the filter cell or icon
+    filter: Filtrer
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Est égal à
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: N’est pas égal à
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Est nulle
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: N’est pas nulle
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Est vide
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: N’est pas vide
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Commence par
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contient
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Ne contient pas
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termine par
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Est supérieur ou égal à
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Est supérieur à
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Est inférieur ou égal à
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Est inférieur
+
+    # The text of the "Is true" filter option
+    filterIsTrue: est vrai
+
+    # The text of the "Is false" filter option
+    filterIsFalse: est fausse
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tout)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Est postérieur ou égal à
+
+    # The text of the after date filter operator
+    filterAfterOperator: Est postérieur
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Est antérieur
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Est antérieur ou égal à
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrer
+
+    # The text of the "clear filter button"
+    filterClearButton: Effacer filtre
+
+    # The text of the "And" filter logic
+    filterAndLogic: Et
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Chargement
+
+    # The label of the sort icon
+    sort: Tri
+
+    # The title of the column menu icon
+    columnMenu: Menu des colonnes
+
+    # The text shown in the column menu for the columns item
+    columns: Colonnes
+
+    # The text shown in the column menu for the lock item
+    lock: Bloquer
+
+    # The text shown in the column menu for the unlock item
+    unlock: Débloquer
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Tri croissant
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Tri décroissant
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Appliquer
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Réinitialiser
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.he-IL.yml
+++ b/messages/treelist/treelist.he-IL.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: כדי לקבץ לפי העמודה גרור כותרת העמודה לכאן
+
+    # The label visible in the Grid when there are no records
+    noRecords: אין רשומות זמינות.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: לעמוד הראשון
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: לעמוד הקודם
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: לעמוד הבא
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: לעמוד האחרון
+
+    # The label before the current page number in the Grid pager
+    pagerPage: עמוד
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: מתוך
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: פריטים
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: פריטים בעמוד
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: שווה ל
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: לא שווה ל
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: הוא null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: הוא לא null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: זה ריק
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: אינו ריק
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: מתחיל עם
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: מכיל
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: לא מכיל
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: נגמר ב
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: גדול או שווה מ
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: גדול מ
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: קטן או שווה ל
+
+    # The text of the "less than" filter operator
+    filterLtOperator: קטן או שווה ל
+
+    # The text of the "Is true" filter option
+    filterIsTrue: כן
+
+    # The text of the "Is false" filter option
+    filterIsFalse: לא
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (את כל)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: אחרי או שווה ל
+
+    # The text of the after date filter operator
+    filterAfterOperator: אחרי
+
+    # The text of the before date filter operator
+    filterBeforeOperator: לפני
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: לפני או שווה ל
+
+    # The text of the "filter button"
+    filterFilterButton: סנן
+
+    # The text of the "clear filter button"
+    filterClearButton: נקה
+
+    # The text of the "And" filter logic
+    filterAndLogic: וגם
+
+    # The text of the "Or" filter logic
+    filterOrLogic: או
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.hy-AM.yml
+++ b/messages/treelist/treelist.hy-AM.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Սյան արժեքները խմբավորելու համար սյան վերնագիրը քաշեք այստեղ։
+
+    # The label visible in the Grid when there are no records
+    noRecords: Հասանելի տվյալներ չկան։
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Վերադառնալ առաջին էջ
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Վերադառնալ նախորդ էջ
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Անցնել հաջորդ էջ
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Անցնել վերջին էջ
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Էջ
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: የ
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: տողերի
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: տողերի քանակ էջում
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: հավասար է
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: հավասար չէ
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: առոչինչ է
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: է ոչ թե անվավեր
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: դատարկ է
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: դատարկ չէ
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: սկասվում է
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: պարունակում է
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: չի պարունակում
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: ավարտվում է
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: մեծ է կամ հավասար
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: մեծ է
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: փոքր է կամ հավասար
+
+    # The text of the "less than" filter operator
+    filterLtOperator: փոքր է կամ հավասար
+
+    # The text of the "Is true" filter option
+    filterIsTrue: ճիշտ է
+
+    # The text of the "Is false" filter option
+    filterIsFalse: սխալ է
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (բոլորը)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: մեծ է կամ հավասար
+
+    # The text of the after date filter operator
+    filterAfterOperator: մեծ է
+
+    # The text of the before date filter operator
+    filterBeforeOperator: փոքր է
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: փոքր է կամ հավասար
+
+    # The text of the "filter button"
+    filterFilterButton: Ֆիլտրել
+
+    # The text of the "clear filter button"
+    filterClearButton: Մաքրել
+
+    # The text of the "And" filter logic
+    filterAndLogic: և
+
+    # The text of the "Or" filter logic
+    filterOrLogic: կամ
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.it-CH.yml
+++ b/messages/treelist/treelist.it-CH.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Trascina l'header di una colonna e rilascialo qui per raggruppare secondo tale colonna
+
+    # The label visible in the Grid when there are no records
+    noRecords: Nessun record disponibile.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Vai alla prima pagina
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Vai alla pagina precedente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Vai alla prossima pagina
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Vai all'ultima pagina
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Pagina
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: di
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: elementi
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: elementi per pagina
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: È uguale a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Non è uguale a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: è zero
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Non è nullo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: è vuoto
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: non è vuoto
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Inizia con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Non contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Finisce con
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: È più grande o uguale a
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: È più grande di
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: È più piccolo o uguale a
+
+    # The text of the "less than" filter operator
+    filterLtOperator: È più piccolo o uguale a
+
+    # The text of the "Is true" filter option
+    filterIsTrue: è vero
+
+    # The text of the "Is false" filter option
+    filterIsFalse: è falso
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tutti)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: È dopo o uguale a
+
+    # The text of the after date filter operator
+    filterAfterOperator: È dopo
+
+    # The text of the before date filter operator
+    filterBeforeOperator: È prima
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: È prima o uguale a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtro
+
+    # The text of the "clear filter button"
+    filterClearButton: Rimuovi
+
+    # The text of the "And" filter logic
+    filterAndLogic: E
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.it-IT.yml
+++ b/messages/treelist/treelist.it-IT.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Trascina l'header di una colonna e rilascialo qui per raggruppare secondo tale colonna
+
+    # The label visible in the Grid when there are no records
+    noRecords: Nessun record disponibile.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Vai alla prima pagina
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Vai alla pagina precedente
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Vai alla prossima pagina
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Vai all'ultima pagina
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Pagina
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: di
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: elementi
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: elementi per pagina
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: È uguale a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Non è uguale a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: È nullo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Non è nullo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: È vuoto
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: Non è vuoto
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Inizia con
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contiene
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Non contiene
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Finisce con
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: È più grande o uguale a
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: È più grande di
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: È più piccolo o uguale a
+
+    # The text of the "less than" filter operator
+    filterLtOperator: È più piccolo o uguale a
+
+    # The text of the "Is true" filter option
+    filterIsTrue: è vero
+
+    # The text of the "Is false" filter option
+    filterIsFalse: è falso
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Tutti)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: È dopo o uguale a
+
+    # The text of the after date filter operator
+    filterAfterOperator: È dopo
+
+    # The text of the before date filter operator
+    filterBeforeOperator: È prima
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: È prima o uguale a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtro
+
+    # The text of the "clear filter button"
+    filterClearButton: Rimuovi
+
+    # The text of the "And" filter logic
+    filterAndLogic: E
+
+    # The text of the "Or" filter logic
+    filterOrLogic: O
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.ja-JP.yml
+++ b/messages/treelist/treelist.ja-JP.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: 列ヘッダーをここにドラッグ アンド ドロップして、その列でグループ化
+
+    # The label visible in the Grid when there are no records
+    noRecords: 利用可能な記録はありません。
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: 最初のページに移動
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: 前のページに移動
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: 次のページに移動
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: 最後のページに移動
+
+    # The label before the current page number in the Grid pager
+    pagerPage: ページ
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: の
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: 項目
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: 項目 (1 ページあたり)
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: が次の値と同じ
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: が次の値と異なる
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: ヌル
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: nullではありません
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: 空です
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: 空ではない
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: が次で始まる
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: が次を含む
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: が次を含まない
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: が次で終わる
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: が次の値以上
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: が次の値より大きい
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: が次の値以下
+
+    # The text of the "less than" filter operator
+    filterLtOperator: が次の値以下
+
+    # The text of the "Is true" filter option
+    filterIsTrue: 真である
+
+    # The text of the "Is false" filter option
+    filterIsFalse: 偽である
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (すべて)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: 次の値と同じかそれより後
+
+    # The text of the after date filter operator
+    filterAfterOperator: 次の値より後
+
+    # The text of the before date filter operator
+    filterBeforeOperator: 次の値より前
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: 次の値と同じかそれより前
+
+    # The text of the "filter button"
+    filterFilterButton: フィルタ
+
+    # The text of the "clear filter button"
+    filterClearButton: クリア
+
+    # The text of the "And" filter logic
+    filterAndLogic: And
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Or
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.nb-NO.yml
+++ b/messages/treelist/treelist.nb-NO.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Dra en kolonne hit for å sortere på den kolonnen
+
+    # The label visible in the Grid when there are no records
+    noRecords: Ingen poster tilgjengelig.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Gå til første side
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Gå til forrige side
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Gå til neste side
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Gå til siste siden
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Side
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: av
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: poster
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: poster per side
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Er lik med
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Er ikke lik med
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: er null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: er ikke null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: er tom
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: er ikke tom
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Starter med
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Inneholder
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Inneholder ikke
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Slutter med
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Er lik eller større enn
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Er større enn
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Er lik eller mindre enn
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Er lik eller mindre enn
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Er sant
+
+    # The text of the "Is false" filter option
+    filterIsFalse: Er usann
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Alle)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Er lik eller senere enn
+
+    # The text of the after date filter operator
+    filterAfterOperator: Er senere enn
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Er tidligere enn
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Er lik eller tidigere enn
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrere
+
+    # The text of the "clear filter button"
+    filterClearButton: Fjern
+
+    # The text of the "And" filter logic
+    filterAndLogic: Og
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Eller
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.nl-BE.yml
+++ b/messages/treelist/treelist.nl-BE.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Sleep een kolomtitel in dit vak om de kolom te groeperen.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Geen verslagen beschikbaar.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ga naar eerste pagina
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ga naar vorige pagina
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ga naar volgende pagina
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ga naar laatste pagina
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Pagina
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: van
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: items
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: items per pagina
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Is gelijk aan
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Is ongelijk aan
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: is niets
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: is niet nul
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: is leeg
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: is niet leeg
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Begint met
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Bevat
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Bevat niet
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Eindigt op
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Is groter of gelijk aan
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Is groter dan
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Is kleiner of gelijk aan
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Is kleiner of gelijk aan
+
+    # The text of the "Is true" filter option
+    filterIsTrue: is waar
+
+    # The text of the "Is false" filter option
+    filterIsFalse: is niet waar
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Alle)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Is op of na
+
+    # The text of the after date filter operator
+    filterAfterOperator: Is na
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Is voor
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Is op of voor
+
+    # The text of the "filter button"
+    filterFilterButton: Filter
+
+    # The text of the "clear filter button"
+    filterClearButton: Filter wissen
+
+    # The text of the "And" filter logic
+    filterAndLogic: En
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Of
+
+    # The loading text
+    loading: Bezig met laden
+
+    # The label of the sort icon
+    sort: Sorteren
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.nl-NL.yml
+++ b/messages/treelist/treelist.nl-NL.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Sleep een kolomtitel in dit vak om de kolom te groeperen.
+
+    # The label visible in the Grid when there are no records
+    noRecords: Geen verslagen beschikbaar.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ga naar eerste pagina
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ga naar vorige pagina
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ga naar volgende pagina
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ga naar laatste pagina
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Pagina
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: van
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: items
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: items per pagina
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Is gelijk aan
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Is ongelijk aan
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: is niets
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: is niet nul
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: is leeg
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: is niet leeg
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Begint met
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Bevat
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Bevat niet
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Eindigt op
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Is groter of gelijk aan
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Is groter dan
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Is kleiner of gelijk aan
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Is kleiner of gelijk aan
+
+    # The text of the "Is true" filter option
+    filterIsTrue: is waar
+
+    # The text of the "Is false" filter option
+    filterIsFalse: is niet waar
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Alle)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Is op of na
+
+    # The text of the after date filter operator
+    filterAfterOperator: Is na
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Is voor
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Is op of voor
+
+    # The text of the "filter button"
+    filterFilterButton: Filter
+
+    # The text of the "clear filter button"
+    filterClearButton: Filter wissen
+
+    # The text of the "And" filter logic
+    filterAndLogic: En
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Of
+
+    # The loading text
+    loading: Bezig met laden
+
+    # The label of the sort icon
+    sort: Sorteren
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.pl-PL.yml
+++ b/messages/treelist/treelist.pl-PL.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Przeciągnij nagłówek kolumny i upuść go tutaj aby pogrupować według tej kolumny
+
+    # The label visible in the Grid when there are no records
+    noRecords: Rejestry dostępne.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Idź do pierwszej strony
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Przejdź do poprzedniej strony
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Przejdź do następnej strony
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Przejdź do ostatniej strony
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Strona
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: z
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: na
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: na stronę
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: są równe
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: są inne niż
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: jest null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Nie jest null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: jest pusty
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: nie jest pusty
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: zaczynają się od
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: zawierają
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: nie zawierają
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: kończą się na
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: są większe lub równe
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: są większe niż
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: są mniejsze lub równe
+
+    # The text of the "less than" filter operator
+    filterLtOperator: są mniejsze lub równe
+
+    # The text of the "Is true" filter option
+    filterIsTrue: prawda
+
+    # The text of the "Is false" filter option
+    filterIsFalse: fałsz
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Wszystko)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: są późniejsze lub równe
+
+    # The text of the after date filter operator
+    filterAfterOperator: są późniejsze niż
+
+    # The text of the before date filter operator
+    filterBeforeOperator: są wcześniejsze niż
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: są wcześniejsze lub równe
+
+    # The text of the "filter button"
+    filterFilterButton: Filtr
+
+    # The text of the "clear filter button"
+    filterClearButton: Wyczyść filtr
+
+    # The text of the "And" filter logic
+    filterAndLogic: Oraz
+
+    # The text of the "Or" filter logic
+    filterOrLogic: lub
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.pt-BR.yml
+++ b/messages/treelist/treelist.pt-BR.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arraste aqui o cabeçalho de uma coluna para agrupar por esta coluna
+
+    # The label visible in the Grid when there are no records
+    noRecords: Nenhum registro encontrado.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir para a primeira página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir para a página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir para a próxima página
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir para a última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: itens
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: itens por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: É igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Não é igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: É nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: É não nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: É vazio
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: É não vazio
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Começa com
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contém
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Não contém
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina com
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: É maior que ou igual a
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: É maior que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: É menor que ou igual a
+
+    # The text of the "less than" filter operator
+    filterLtOperator: É menor que ou igual a
+
+    # The text of the "Is true" filter option
+    filterIsTrue: É verdade
+
+    # The text of the "Is false" filter option
+    filterIsFalse: É falso
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todos)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: É posterior ou igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: É posterior a
+
+    # The text of the before date filter operator
+    filterBeforeOperator: É anterior a
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: É anterior ou igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpar
+
+    # The text of the "And" filter logic
+    filterAndLogic: E
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Ou
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.pt-PT.yml
+++ b/messages/treelist/treelist.pt-PT.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Arraste uma coluna para este espaço para agrupar pelo valor da mesma
+
+    # The label visible in the Grid when there are no records
+    noRecords: Nenhum registo disponível.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Ir para a primeira página
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Ir para a página anterior
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Ir para a próxima página
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ir para a última página
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Página
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: de
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: itens
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: itens por página
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: É igual a
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Não é igual a
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: É nulo
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: É não nulo
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: É vazio
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: É não vazio
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Começa com
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Contém
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Não contém
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Termina com
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: É maior ou igual a
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: É maior que
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: É menor ou igual a
+
+    # The text of the "less than" filter operator
+    filterLtOperator: É menor ou igual a
+
+    # The text of the "Is true" filter option
+    filterIsTrue: é verdadeiro
+
+    # The text of the "Is false" filter option
+    filterIsFalse: é falso
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Todos)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: É posterior ou igual a
+
+    # The text of the after date filter operator
+    filterAfterOperator: É posterior a
+
+    # The text of the before date filter operator
+    filterBeforeOperator: É anterior a
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: É anterior ou igual a
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrar
+
+    # The text of the "clear filter button"
+    filterClearButton: Limpar
+
+    # The text of the "And" filter logic
+    filterAndLogic: E
+
+    # The text of the "Or" filter logic
+    filterOrLogic: OU
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.ro-RO.yml
+++ b/messages/treelist/treelist.ro-RO.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Trageți un antet de coloană și plasați-l aici pentru a grupa după acea coloană
+
+    # The label visible in the Grid when there are no records
+    noRecords: Nu exista inregistrari disponibile.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Prima pagină
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Pagina precedentă
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Pagina următoare
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Ultima pagină
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Pagina
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: din
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: elemente
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: elemente per pagină
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Egal cu
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Diferit de
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: este nul
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: nu este nul
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: este gol
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: nu este gol
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Începe cu
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Conține
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Nu conține
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Se termină cu
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Mai mare sau egal cu
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Mai mare decât
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Mai mic sau egal cu
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Mai mic sau egal cu
+
+    # The text of the "Is true" filter option
+    filterIsTrue: este adevărat
+
+    # The text of the "Is false" filter option
+    filterIsFalse: este fals
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Toate)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: După sau egal cu
+
+    # The text of the after date filter operator
+    filterAfterOperator: După
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Înainte de
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Înainte sau egal cu
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrează
+
+    # The text of the "clear filter button"
+    filterClearButton: Șterge
+
+    # The text of the "And" filter logic
+    filterAndLogic: Și
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Sau
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.ru-RU.yml
+++ b/messages/treelist/treelist.ru-RU.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Перетаскивайте сюда заголовки колонок, чтобы сгруппировать по ним
+
+    # The label visible in the Grid when there are no records
+    noRecords: Нет записей.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Перейти на первую страницу
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Перейти на предыдущую страницу
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Перейти на следующую страницу
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Перейти на последнюю страницу
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Страница
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: из
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: элементов
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: элементов на странице
+
+    # The label of the filter cell or icon
+    filter: Фильтр
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Равно
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Не равно
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Нет значения
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Есть значение
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Пусто
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: Не пусто
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Начинается с
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Содержит
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Не содержит
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Заканчивается на
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Больше или равно
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Больше чем
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Меньше или равно
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Меньше чем
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Да
+
+    # The text of the "Is false" filter option
+    filterIsFalse: Нет
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Все)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Позже или равна
+
+    # The text of the after date filter operator
+    filterAfterOperator: Позже чем
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Раньше чем
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Раньше или равна
+
+    # The text of the "filter button"
+    filterFilterButton: Отфильтровать
+
+    # The text of the "clear filter button"
+    filterClearButton: Сбросить
+
+    # The text of the "And" filter logic
+    filterAndLogic: И
+
+    # The text of the "Or" filter logic
+    filterOrLogic: ИЛИ
+
+    # The loading text
+    loading: Загрузка
+
+    # The label of the sort icon
+    sort: Сортировать
+
+    # The title of the column menu icon
+    columnMenu: Меню колонки
+
+    # The text shown in the column menu for the columns item
+    columns: Колонки
+
+    # The text shown in the column menu for the lock item
+    lock: Заблокировать
+
+    # The text shown in the column menu for the unlock item
+    unlock: Разблокировать
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Отсортировать по возрастанию
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Отсортировать по убыванию
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Применить
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Сбросить
+
+    # The label of the sort icon
+    sortable: Можно сортировать
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Отсортировано по возрастанию
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Отсортировано по убыванию
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Сортировка сброшена
+

--- a/messages/treelist/treelist.sk-SK.yml
+++ b/messages/treelist/treelist.sk-SK.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Potiahnite sem záhlavie stĺpca na zoskupenie podľa neho
+
+    # The label visible in the Grid when there are no records
+    noRecords: Žiadne záznamy.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Prejsť na prvú stranu
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Prejsť na predošlú stranu
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Prejsť na ďalšiu stranu
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Prejsť na poslednú stranu
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Strana
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: z
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: záznamov
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: záznamov na stranu
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Je
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Nie je
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Je null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Nie je null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: Je prázdne
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: Nie je prázdne
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Začína s
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Obsahuje
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Neobsahuje
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Končí s
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Je väčšie alebo sa rovná
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Je väčšie ako
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Je menšie alebo sa rovná
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Je menšie alebo sa rovná
+
+    # The text of the "Is true" filter option
+    filterIsTrue: je pravda
+
+    # The text of the "Is false" filter option
+    filterIsFalse: nie je pravda
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Všetko)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Nasleduje alebo je
+
+    # The text of the after date filter operator
+    filterAfterOperator: Nasleduje
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Predchádza
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Predchádza alebo je
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrovať
+
+    # The text of the "clear filter button"
+    filterClearButton: Vyčistiť
+
+    # The text of the "And" filter logic
+    filterAndLogic: A zároveň
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Alebo
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.sv-SE.yml
+++ b/messages/treelist/treelist.sv-SE.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Dra en kolumnrubrik hit för att sortera på den kolumnen
+
+    # The label visible in the Grid when there are no records
+    noRecords: Inga uppgifter tillgängliga.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Gå till första sidan
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Gå till föregående sida
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Gå till nästa sida
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Gå till sista sidan
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Sida
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: av
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: poster
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: poster per sida
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Är lika med
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Är inte lika med
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: är inget
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: är inte null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: är tom
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: är inte tom
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: Börjar med
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: Innehåller
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Innehåller inte
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: Slutar med
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Är lika eller större än
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Är större än
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Är lika eller mindre än
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Är lika eller mindre än
+
+    # The text of the "Is true" filter option
+    filterIsTrue: är sant
+
+    # The text of the "Is false" filter option
+    filterIsFalse: är falskt
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Allt)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Är lika eller senare än
+
+    # The text of the after date filter operator
+    filterAfterOperator: Är senare än
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Är tidigare än
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Är lika eller tidigare än
+
+    # The text of the "filter button"
+    filterFilterButton: Filtrera
+
+    # The text of the "clear filter button"
+    filterClearButton: Rensa
+
+    # The text of the "And" filter logic
+    filterAndLogic: Och
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Eller
+
+    # The loading text
+    loading: Laddar
+
+    # The label of the sort icon
+    sort: Sortera
+
+    # The title of the column menu icon
+    columnMenu: Kolumnmeny
+
+    # The text shown in the column menu for the columns item
+    columns: Kolumner
+
+    # The text shown in the column menu for the lock item
+    lock: Lås
+
+    # The text shown in the column menu for the unlock item
+    unlock: Lås upp
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sortera Stigande
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sortera Fallande
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Tillämpa
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Återställ
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.tr-TR.yml
+++ b/messages/treelist/treelist.tr-TR.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Bir sütun başlığını sürükleyin ve bu sütuna göre gruplandırmak için buraya bırakın
+
+    # The label visible in the Grid when there are no records
+    noRecords: Kayıt mevcut değil.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: İlk sayfaya git
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Sayfaları İncele
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Bir sonraki sayfaya git
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: Son sayfaya git
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Sayfa
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: {0}
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: Sayfa
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: Sayfa başına ürün
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: Eşittir
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: Eşit değildir
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: Boştur
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: Boş değil
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: boş
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: boş değil
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: İle başlar
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: İçeriyor
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: İçermiyor
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: İle biter
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: Daha büyük veya eşittir
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: Büyüktür
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: Daha küçük veya eşit
+
+    # The text of the "less than" filter operator
+    filterLtOperator: Daha küçük veya eşit
+
+    # The text of the "Is true" filter option
+    filterIsTrue: Doğru
+
+    # The text of the "Is false" filter option
+    filterIsFalse: Yanlış
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (Herşey)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: Sonra ya da eşit
+
+    # The text of the after date filter operator
+    filterAfterOperator: Sonra
+
+    # The text of the before date filter operator
+    filterBeforeOperator: Önce
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: Önce ya da eşit
+
+    # The text of the "filter button"
+    filterFilterButton: Filtre
+
+    # The text of the "clear filter button"
+    filterClearButton: Temizle
+
+    # The text of the "And" filter logic
+    filterAndLogic: Ve
+
+    # The text of the "Or" filter logic
+    filterOrLogic: ya da
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.uk-UA.yml
+++ b/messages/treelist/treelist.uk-UA.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: Перетягніть сюди заголовок стовпця, щоб згрупувати записи з цього стовпця
+
+    # The label visible in the Grid when there are no records
+    noRecords: Немає записів доступні.
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: Повернутися на першу сторінку
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: Перейти на попередню сторінку
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: Перейдіть на наступну сторінку
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: До останньої сторінки
+
+    # The label before the current page number in the Grid pager
+    pagerPage: Сторінка
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: з
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: елементів
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: елементів на сторінці
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: рівні
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: не рівні
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: дорівнює нулю
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: не є нульовим
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: пусто
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: не порожньо
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: починаються на
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: містять
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: Does not contain
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: закінчуються на
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: більше або рівними
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: більше
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: менше або рівними
+
+    # The text of the "less than" filter operator
+    filterLtOperator: менше або рівними
+
+    # The text of the "Is true" filter option
+    filterIsTrue: істина
+
+    # The text of the "Is false" filter option
+    filterIsFalse: хиба
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (всі)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: після або рівна
+
+    # The text of the after date filter operator
+    filterAfterOperator: після
+
+    # The text of the before date filter operator
+    filterBeforeOperator: до
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: до або рівними
+
+    # The text of the "filter button"
+    filterFilterButton: фільтрувати
+
+    # The text of the "clear filter button"
+    filterClearButton: очистити
+
+    # The text of the "And" filter logic
+    filterAndLogic: І
+
+    # The text of the "Or" filter logic
+    filterOrLogic: Or
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.zh-CN.yml
+++ b/messages/treelist/treelist.zh-CN.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: 拖拽列标题到此处按列组合显示
+
+    # The label visible in the Grid when there are no records
+    noRecords: 没有可用的记录。
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: 首页
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: 上一页
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: 下一页
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: 末页
+
+    # The label before the current page number in the Grid pager
+    pagerPage: 页
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: 共
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: 每页
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: 每页
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: 等于
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: 不等于
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: 不为null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: 为null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: 是空的
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: 不是空的
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: 开头为
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: 包含
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: 不包含
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: 结尾为
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: 大于等于
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: 大于
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: 小于等于
+
+    # The text of the "less than" filter operator
+    filterLtOperator: 小于等于
+
+    # The text of the "Is true" filter option
+    filterIsTrue: 为真
+
+    # The text of the "Is false" filter option
+    filterIsFalse: 为假
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (所有)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: 大于等于
+
+    # The text of the after date filter operator
+    filterAfterOperator: 大于
+
+    # The text of the before date filter operator
+    filterBeforeOperator: 小于
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: 小于等于
+
+    # The text of the "filter button"
+    filterFilterButton: 过滤
+
+    # The text of the "clear filter button"
+    filterClearButton: 清除
+
+    # The text of the "And" filter logic
+    filterAndLogic: 并且
+
+    # The text of the "Or" filter logic
+    filterOrLogic: 或
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.zh-HK.yml
+++ b/messages/treelist/treelist.zh-HK.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: 拖拽列標題到此處按列組合顯示
+
+    # The label visible in the Grid when there are no records
+    noRecords: 沒有可用的記錄。
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: 首頁
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: 上一頁
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: 下一頁
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: 末頁
+
+    # The label before the current page number in the Grid pager
+    pagerPage: 頁
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: 共
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: 每頁
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: 每頁
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: 等於
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: 不等於
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: 为null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: 不为null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: 是空的
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: 不是空的
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: 開頭為
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: 包含
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: 不包含
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: 結尾為
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: 大於等於
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: 大於
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: 小於等於
+
+    # The text of the "less than" filter operator
+    filterLtOperator: 小於等於
+
+    # The text of the "Is true" filter option
+    filterIsTrue: 為真
+
+    # The text of the "Is false" filter option
+    filterIsFalse: 為假
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (所有)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: 大於等於
+
+    # The text of the after date filter operator
+    filterAfterOperator: 大於
+
+    # The text of the before date filter operator
+    filterBeforeOperator: 小於
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: 小於等於
+
+    # The text of the "filter button"
+    filterFilterButton: 過濾
+
+    # The text of the "clear filter button"
+    filterClearButton: 清除
+
+    # The text of the "And" filter logic
+    filterAndLogic: 並且
+
+    # The text of the "Or" filter logic
+    filterOrLogic: 或
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+

--- a/messages/treelist/treelist.zh-TW.yml
+++ b/messages/treelist/treelist.zh-TW.yml
@@ -1,0 +1,152 @@
+kendo:
+  treelist:
+    # The label visible in the Grid group panel when it is empty
+    groupPanelEmpty: 拖拽列標題到此處按列組合顯示
+
+    # The label visible in the Grid when there are no records
+    noRecords: 沒有可用的記錄。
+
+    # The label for the first page button in Grid pager
+    pagerFirstPage: 首頁
+
+    # The label for the previous page button in Grid pager
+    pagerPreviousPage: 上一頁
+
+    # The label for the next page button in Grid pager
+    pagerNextPage: 下一頁
+
+    # The label for the last page button in Grid pager
+    pagerLastPage: 末頁
+
+    # The label before the current page number in the Grid pager
+    pagerPage: 頁
+
+    # The label before the total pages number in the Grid pager
+    pagerOf: 共
+
+    # The label after the total items count in the TreeList pager
+    pagerItemsTotal: 每頁
+
+    # The label for the page size chooser in the Grid pager
+    pagerItemsPerPage: 每頁
+
+    # The label of the filter cell or icon
+    filter: Filter
+
+    # The text of the "equal" filter operator
+    filterEqOperator: 等於
+
+    # The text of the "not equal" filter operator
+    filterNotEqOperator: 不等於
+
+    # The text of the "is null" filter operator
+    filterIsNullOperator: 为null
+
+    # The text of the "is not null" filter operator
+    filterIsNotNullOperator: 不为null
+
+    # The text of the "is empty" filter operator
+    filterIsEmptyOperator: 是空的
+
+    # The text of the "is not empty" filter operator
+    filterIsNotEmptyOperator: 不是空的
+
+    # The text of the "starts with" filter operator
+    filterStartsWithOperator: 開頭為
+
+    # The text of the "contains" filter operator
+    filterContainsOperator: 包含
+
+    # The text of the "does not contain" filter operator
+    filterNotContainsOperator: 不包含
+
+    # The text of the "ends with" filter operator
+    filterEndsWithOperator: 結尾為
+
+    # The text of the "greater than or equal" filter operator
+    filterGteOperator: 大於等於
+
+    # The text of the "greater than" filter operator
+    filterGtOperator: 大於
+
+    # The text of the "less than or equal" filter operator
+    filterLteOperator: 小於等於
+
+    # The text of the "less than" filter operator
+    filterLtOperator: 小於等於
+
+    # The text of the "Is true" filter option
+    filterIsTrue: 為真
+
+    # The text of the "Is false" filter option
+    filterIsFalse: 為假
+
+    # The text of the (All) boolean filter option
+    filterBooleanAll: (所有)
+
+    # The text of the after or equal date filter operator
+    filterAfterOrEqualOperator: 大於等於
+
+    # The text of the after date filter operator
+    filterAfterOperator: 大於
+
+    # The text of the before date filter operator
+    filterBeforeOperator: 小於
+
+    # The text of the before or equal date filter operator
+    filterBeforeOrEqualOperator: 小於等於
+
+    # The text of the "filter button"
+    filterFilterButton: 過濾
+
+    # The text of the "clear filter button"
+    filterClearButton: 清除
+
+    # The text of the "And" filter logic
+    filterAndLogic: 並且
+
+    # The text of the "Or" filter logic
+    filterOrLogic: 或
+
+    # The loading text
+    loading: Loading
+
+    # The label of the sort icon
+    sort: Sort
+
+    # The title of the column menu icon
+    columnMenu: Column Menu
+
+    # The text shown in the column menu for the columns item
+    columns: Columns
+
+    # The text shown in the column menu for the lock item
+    lock: Lock
+
+    # The text shown in the column menu for the unlock item
+    unlock: Unlock
+
+    # The text shown in the column menu for the sort ascending item
+    sortAscending: Sort Ascending
+
+    # The text shown in the column menu for the sort descending item
+    sortDescending: Sort Descending
+
+    # The text shown in the column menu or column chooser for the columns apply button
+    columnsApply: Apply
+
+    # The text shown in the column menu or column chooser for the columns reset button
+    columnsReset: Reset
+
+    # The label of the sort icon
+    sortable: Sortable
+
+    # The status announcement when a column is sorted ascending
+    sortedAscending: Sorted ascending
+
+    # The status announcement when a column is sorted descending
+    sortedDescending: Sorted descending
+
+    # The status announcement when a column is no longer sorted
+    sortedDefault: Not sorted
+


### PR DESCRIPTION
Same as the Grid messages with the exception of `pagerItems`.

It is replaced by `pagerItemsTotal` to signify the different usage:
* *"10 - 20 of 1055 **items**"* in the Grid vs.
* *"Page 2 of 3 (1055 **items total**)"* in the TreeList.