### PR TITLE
feat: add translations for numeric and date grid filter messages

### DIFF
--- a/messages/grid/grid.ar.yml
+++ b/messages/grid/grid.ar.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Or
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: تغيير التقويم
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: اليوم
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: تخفيض القيمة
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: زيادة القيمة
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.bg-BG.yml
+++ b/messages/grid/grid.bg-BG.yml
@@ -109,6 +109,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: или
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Днес
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Намали стойността
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Увеличи стойността
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.cs-CZ.yml
+++ b/messages/grid/grid.cs-CZ.yml
@@ -109,6 +109,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Nebo
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Zobrazit/skrýt kalendář
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Dnes
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Zmenšit
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Zvětšit
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.da-DK.yml
+++ b/messages/grid/grid.da-DK.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Eller
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: I dag
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Zmenšit
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Zvětšit
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.de-AT.yml
+++ b/messages/grid/grid.de-AT.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: oder
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Heute
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Wert verringern
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Wert erhöhen
+
     # The loading text
     loading: Laden
 

--- a/messages/grid/grid.de-CH.yml
+++ b/messages/grid/grid.de-CH.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: oder
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Heute
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Wert verringern
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Wert erhöhen
+
     # The loading text
     loading: Laden
 

--- a/messages/grid/grid.de-DE.yml
+++ b/messages/grid/grid.de-DE.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: oder
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Kalender umschalten
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Heute
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Wert verringern
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Wert erhöhen
+
     # The loading text
     loading: Laden
 

--- a/messages/grid/grid.de-LI.yml
+++ b/messages/grid/grid.de-LI.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: oder
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Heute
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Wert verringern
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Wert erhöhen
+
     # The loading text
     loading: Laden
 

--- a/messages/grid/grid.en-AU.yml
+++ b/messages/grid/grid.en-AU.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Or
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Today
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Decrease value
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Increase value
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.en-CA.yml
+++ b/messages/grid/grid.en-CA.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Or
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Today
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Decrease value
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Increase value
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.en-GB.yml
+++ b/messages/grid/grid.en-GB.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Or
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Today
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Decrease value
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Increase value
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.en-US.yml
+++ b/messages/grid/grid.en-US.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Or
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Today
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Decrease value
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Increase value
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-AR.yml
+++ b/messages/grid/grid.es-AR.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-BO.yml
+++ b/messages/grid/grid.es-BO.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-CL.yml
+++ b/messages/grid/grid.es-CL.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-CO.yml
+++ b/messages/grid/grid.es-CO.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-CR.yml
+++ b/messages/grid/grid.es-CR.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-DO.yml
+++ b/messages/grid/grid.es-DO.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-EC.yml
+++ b/messages/grid/grid.es-EC.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-ES.yml
+++ b/messages/grid/grid.es-ES.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-GT.yml
+++ b/messages/grid/grid.es-GT.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-HN.yml
+++ b/messages/grid/grid.es-HN.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-MX.yml
+++ b/messages/grid/grid.es-MX.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-NI.yml
+++ b/messages/grid/grid.es-NI.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-PA.yml
+++ b/messages/grid/grid.es-PA.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-PE.yml
+++ b/messages/grid/grid.es-PE.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-PR.yml
+++ b/messages/grid/grid.es-PR.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-PY.yml
+++ b/messages/grid/grid.es-PY.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-US.yml
+++ b/messages/grid/grid.es-US.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-UY.yml
+++ b/messages/grid/grid.es-UY.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.es-VE.yml
+++ b/messages/grid/grid.es-VE.yml
@@ -106,6 +106,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoy
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Disminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Incrementar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.fa-IR.yml
+++ b/messages/grid/grid.fa-IR.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: یا
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: تقویم را تغییر وضعیت بده
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: امروز
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: مقدار را کاهش بده
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: مقدار را افزایش بده
+
     # The loading text
     loading: لطفا صبر کنید
 

--- a/messages/grid/grid.fi-FI.yml
+++ b/messages/grid/grid.fi-FI.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Tai
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Tänään
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Vähennä arvoa
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Kasvata arvoa
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.fr-BE.yml
+++ b/messages/grid/grid.fr-BE.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-CA.yml
+++ b/messages/grid/grid.fr-CA.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-CD.yml
+++ b/messages/grid/grid.fr-CD.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-CH.yml
+++ b/messages/grid/grid.fr-CH.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-CI.yml
+++ b/messages/grid/grid.fr-CI.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-CM.yml
+++ b/messages/grid/grid.fr-CM.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-FR.yml
+++ b/messages/grid/grid.fr-FR.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-HT.yml
+++ b/messages/grid/grid.fr-HT.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-LU.yml
+++ b/messages/grid/grid.fr-LU.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-MA.yml
+++ b/messages/grid/grid.fr-MA.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-MC.yml
+++ b/messages/grid/grid.fr-MC.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-ML.yml
+++ b/messages/grid/grid.fr-ML.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.fr-SN.yml
+++ b/messages/grid/grid.fr-SN.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Afficher le calendrier
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Aujourd'hui
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuer la valeur
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Augmenter la valeur
+
     # The loading text
     loading: Chargement
 

--- a/messages/grid/grid.he-IL.yml
+++ b/messages/grid/grid.he-IL.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: או
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: היום
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: למטה
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: למעלה
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.hy-AM.yml
+++ b/messages/grid/grid.hy-AM.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: կամ
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Today
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: למטה
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: למעלה
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.it-CH.yml
+++ b/messages/grid/grid.it-CH.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Oggi
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: למטה
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: למעלה
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.it-IT.yml
+++ b/messages/grid/grid.it-IT.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: O
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Oggi
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: למטה
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: למעלה
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.ja-JP.yml
+++ b/messages/grid/grid.ja-JP.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Or
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: 今日
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: 値を減らす
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: 値を増やす
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.nb-NO.yml
+++ b/messages/grid/grid.nb-NO.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Eller
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: I dag
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: 値を減らす
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: 値を増やす
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.nl-BE.yml
+++ b/messages/grid/grid.nl-BE.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Of
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Vandaag
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Verlagen
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Verhogen
+
     # The loading text
     loading: Bezig met laden
 

--- a/messages/grid/grid.nl-NL.yml
+++ b/messages/grid/grid.nl-NL.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Of
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Vandaag
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Verlagen
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Verhogen
+
     # The loading text
     loading: Bezig met laden
 

--- a/messages/grid/grid.pl-PL.yml
+++ b/messages/grid/grid.pl-PL.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: lub
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Today
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: 値を減らす
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: 値を増やす
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.pt-BR.yml
+++ b/messages/grid/grid.pt-BR.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Ou
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoje
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Aumentar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.pt-PT.yml
+++ b/messages/grid/grid.pt-PT.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: OU
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Hoje
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Aumentar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.ro-RO.yml
+++ b/messages/grid/grid.ro-RO.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Sau
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Astăzi
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Diminuir valor
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Aumentar valor
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.ru-RU.yml
+++ b/messages/grid/grid.ru-RU.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: ИЛИ
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Переключить календарь
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Сегодня
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Уменьшить значение
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Увеличить значение
+
     # The loading text
     loading: Загрузка
 

--- a/messages/grid/grid.sk-SK.yml
+++ b/messages/grid/grid.sk-SK.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Alebo
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Dnes
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Znížiť hodnotu
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Zvýšiť hodnotu
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.sv-SE.yml
+++ b/messages/grid/grid.sv-SE.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Eller
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Idag
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Minska värde
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Öka värde
+
     # The loading text
     loading: Laddar
 

--- a/messages/grid/grid.tr-TR.yml
+++ b/messages/grid/grid.tr-TR.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: ya da
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Bugün
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Znížiť hodnotu
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Zvýšiť hodnotu
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.uk-UA.yml
+++ b/messages/grid/grid.uk-UA.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: Or
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: Today
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: Znížiť hodnotu
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: Zvýšiť hodnotu
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.zh-CN.yml
+++ b/messages/grid/grid.zh-CN.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: 或
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: 今天
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: 减少
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: 增加
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.zh-HK.yml
+++ b/messages/grid/grid.zh-HK.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: 或
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: 今天
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: 減少
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: 增加
+
     # The loading text
     loading: Loading
 

--- a/messages/grid/grid.zh-TW.yml
+++ b/messages/grid/grid.zh-TW.yml
@@ -108,6 +108,18 @@ kendo:
     # The text of the "Or" filter logic
     filterOrLogic: 或
 
+    # The title of the Toggle button of the Date filter.
+    filterDateToggle: Toggle calendar
+
+    # The text of the Today button of the Date filter.
+    filterDateToday: 今天
+
+    # The title of the Decrement button of the Numeric filter.
+    filterNumericDecrement: 減少
+
+    # The title of the Increment button of the Numeric filter.
+    filterNumericIncrement: 增加
+
     # The loading text
     loading: Loading
 


### PR DESCRIPTION
The messages are scraped with a script, so if there are comments on the key descriptions, they can easily be addressed.