### PR TITLE
chore: fix publish permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
 
     permissions:
         id-token: write # Required by Akeyless
-        contents: read
+        contents: write
         packages: read
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     concurrency:
-        group: ${{ github.ref }}-ci
-        cancel-in-progress: true
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Semantic release seems to check the repo write access before publishing. 