### PR TITLE
Add missing messages for stepper and dropdowns

### DIFF
--- a/messages/dropdowns/dropdowns.ar.yml
+++ b/messages/dropdowns/dropdowns.ar.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.ar.yml
+++ b/messages/dropdowns/dropdowns.ar.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.bg-BG.yml
+++ b/messages/dropdowns/dropdowns.bg-BG.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Филтър
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Няма данни

--- a/messages/dropdowns/dropdowns.bg-BG.yml
+++ b/messages/dropdowns/dropdowns.bg-BG.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Списък с опции
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.cs-CZ.yml
+++ b/messages/dropdowns/dropdowns.cs-CZ.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.cs-CZ.yml
+++ b/messages/dropdowns/dropdowns.cs-CZ.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Nenalezena žádná data

--- a/messages/dropdowns/dropdowns.da-DK.yml
+++ b/messages/dropdowns/dropdowns.da-DK.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Ingen data fundet

--- a/messages/dropdowns/dropdowns.da-DK.yml
+++ b/messages/dropdowns/dropdowns.da-DK.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.de-AT.yml
+++ b/messages/dropdowns/dropdowns.de-AT.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Anwenden
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Abbrechen
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Alle auswählen
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.de-AT.yml
+++ b/messages/dropdowns/dropdowns.de-AT.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Anwenden
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Abbrechen

--- a/messages/dropdowns/dropdowns.de-CH.yml
+++ b/messages/dropdowns/dropdowns.de-CH.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Anwenden
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Abbrechen
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Alle auswählen
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.de-CH.yml
+++ b/messages/dropdowns/dropdowns.de-CH.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Anwenden
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Abbrechen

--- a/messages/dropdowns/dropdowns.de-DE.yml
+++ b/messages/dropdowns/dropdowns.de-DE.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Anwenden
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Abbrechen

--- a/messages/dropdowns/dropdowns.de-DE.yml
+++ b/messages/dropdowns/dropdowns.de-DE.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Anwenden
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Abbrechen
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Alle auswählen
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Keine Daten gefunden

--- a/messages/dropdowns/dropdowns.de-LI.yml
+++ b/messages/dropdowns/dropdowns.de-LI.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.de-LI.yml
+++ b/messages/dropdowns/dropdowns.de-LI.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.en-AU.yml
+++ b/messages/dropdowns/dropdowns.en-AU.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.en-AU.yml
+++ b/messages/dropdowns/dropdowns.en-AU.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.en-CA.yml
+++ b/messages/dropdowns/dropdowns.en-CA.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.en-CA.yml
+++ b/messages/dropdowns/dropdowns.en-CA.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.en-GB.yml
+++ b/messages/dropdowns/dropdowns.en-GB.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.en-GB.yml
+++ b/messages/dropdowns/dropdowns.en-GB.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.en-US.yml
+++ b/messages/dropdowns/dropdowns.en-US.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.en-US.yml
+++ b/messages/dropdowns/dropdowns.en-US.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-AR.yml
+++ b/messages/dropdowns/dropdowns.es-AR.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-AR.yml
+++ b/messages/dropdowns/dropdowns.es-AR.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-BO.yml
+++ b/messages/dropdowns/dropdowns.es-BO.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-BO.yml
+++ b/messages/dropdowns/dropdowns.es-BO.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-CL.yml
+++ b/messages/dropdowns/dropdowns.es-CL.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-CL.yml
+++ b/messages/dropdowns/dropdowns.es-CL.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-CO.yml
+++ b/messages/dropdowns/dropdowns.es-CO.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-CO.yml
+++ b/messages/dropdowns/dropdowns.es-CO.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-CR.yml
+++ b/messages/dropdowns/dropdowns.es-CR.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-CR.yml
+++ b/messages/dropdowns/dropdowns.es-CR.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-DO.yml
+++ b/messages/dropdowns/dropdowns.es-DO.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-DO.yml
+++ b/messages/dropdowns/dropdowns.es-DO.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-EC.yml
+++ b/messages/dropdowns/dropdowns.es-EC.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-EC.yml
+++ b/messages/dropdowns/dropdowns.es-EC.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-ES.yml
+++ b/messages/dropdowns/dropdowns.es-ES.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-ES.yml
+++ b/messages/dropdowns/dropdowns.es-ES.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-GT.yml
+++ b/messages/dropdowns/dropdowns.es-GT.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-GT.yml
+++ b/messages/dropdowns/dropdowns.es-GT.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-HN.yml
+++ b/messages/dropdowns/dropdowns.es-HN.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-HN.yml
+++ b/messages/dropdowns/dropdowns.es-HN.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-MX.yml
+++ b/messages/dropdowns/dropdowns.es-MX.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-MX.yml
+++ b/messages/dropdowns/dropdowns.es-MX.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-NI.yml
+++ b/messages/dropdowns/dropdowns.es-NI.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-NI.yml
+++ b/messages/dropdowns/dropdowns.es-NI.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-PA.yml
+++ b/messages/dropdowns/dropdowns.es-PA.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-PA.yml
+++ b/messages/dropdowns/dropdowns.es-PA.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-PE.yml
+++ b/messages/dropdowns/dropdowns.es-PE.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-PE.yml
+++ b/messages/dropdowns/dropdowns.es-PE.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-PR.yml
+++ b/messages/dropdowns/dropdowns.es-PR.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-PR.yml
+++ b/messages/dropdowns/dropdowns.es-PR.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-PY.yml
+++ b/messages/dropdowns/dropdowns.es-PY.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-PY.yml
+++ b/messages/dropdowns/dropdowns.es-PY.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-US.yml
+++ b/messages/dropdowns/dropdowns.es-US.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-US.yml
+++ b/messages/dropdowns/dropdowns.es-US.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-UY.yml
+++ b/messages/dropdowns/dropdowns.es-UY.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-UY.yml
+++ b/messages/dropdowns/dropdowns.es-UY.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.es-VE.yml
+++ b/messages/dropdowns/dropdowns.es-VE.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.es-VE.yml
+++ b/messages/dropdowns/dropdowns.es-VE.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fa-IR.yml
+++ b/messages/dropdowns/dropdowns.fa-IR.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: هیچ داده‌ای یافت نشد

--- a/messages/dropdowns/dropdowns.fa-IR.yml
+++ b/messages/dropdowns/dropdowns.fa-IR.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fi-FI.yml
+++ b/messages/dropdowns/dropdowns.fi-FI.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.fi-FI.yml
+++ b/messages/dropdowns/dropdowns.fi-FI.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-BE.yml
+++ b/messages/dropdowns/dropdowns.fr-BE.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-BE.yml
+++ b/messages/dropdowns/dropdowns.fr-BE.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-CA.yml
+++ b/messages/dropdowns/dropdowns.fr-CA.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-CA.yml
+++ b/messages/dropdowns/dropdowns.fr-CA.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-CD.yml
+++ b/messages/dropdowns/dropdowns.fr-CD.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-CD.yml
+++ b/messages/dropdowns/dropdowns.fr-CD.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-CH.yml
+++ b/messages/dropdowns/dropdowns.fr-CH.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-CH.yml
+++ b/messages/dropdowns/dropdowns.fr-CH.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-CI.yml
+++ b/messages/dropdowns/dropdowns.fr-CI.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-CI.yml
+++ b/messages/dropdowns/dropdowns.fr-CI.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-CM.yml
+++ b/messages/dropdowns/dropdowns.fr-CM.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-CM.yml
+++ b/messages/dropdowns/dropdowns.fr-CM.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-FR.yml
+++ b/messages/dropdowns/dropdowns.fr-FR.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-FR.yml
+++ b/messages/dropdowns/dropdowns.fr-FR.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-HT.yml
+++ b/messages/dropdowns/dropdowns.fr-HT.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-HT.yml
+++ b/messages/dropdowns/dropdowns.fr-HT.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-LU.yml
+++ b/messages/dropdowns/dropdowns.fr-LU.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-LU.yml
+++ b/messages/dropdowns/dropdowns.fr-LU.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-MA.yml
+++ b/messages/dropdowns/dropdowns.fr-MA.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-MA.yml
+++ b/messages/dropdowns/dropdowns.fr-MA.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-MC.yml
+++ b/messages/dropdowns/dropdowns.fr-MC.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-MC.yml
+++ b/messages/dropdowns/dropdowns.fr-MC.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-ML.yml
+++ b/messages/dropdowns/dropdowns.fr-ML.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-ML.yml
+++ b/messages/dropdowns/dropdowns.fr-ML.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.fr-SN.yml
+++ b/messages/dropdowns/dropdowns.fr-SN.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Aucun enregistrement trouvé

--- a/messages/dropdowns/dropdowns.fr-SN.yml
+++ b/messages/dropdowns/dropdowns.fr-SN.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.he-IL.yml
+++ b/messages/dropdowns/dropdowns.he-IL.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.he-IL.yml
+++ b/messages/dropdowns/dropdowns.he-IL.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.hy-AM.yml
+++ b/messages/dropdowns/dropdowns.hy-AM.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.hy-AM.yml
+++ b/messages/dropdowns/dropdowns.hy-AM.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.it-CH.yml
+++ b/messages/dropdowns/dropdowns.it-CH.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.it-CH.yml
+++ b/messages/dropdowns/dropdowns.it-CH.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Nessun dato trovato

--- a/messages/dropdowns/dropdowns.it-IT.yml
+++ b/messages/dropdowns/dropdowns.it-IT.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.it-IT.yml
+++ b/messages/dropdowns/dropdowns.it-IT.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Nessun dato trovato

--- a/messages/dropdowns/dropdowns.ja-JP.yml
+++ b/messages/dropdowns/dropdowns.ja-JP.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.ja-JP.yml
+++ b/messages/dropdowns/dropdowns.ja-JP.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.ka-GE.yml
+++ b/messages/dropdowns/dropdowns.ka-GE.yml
@@ -89,3 +89,8 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.ka-GE.yml
+++ b/messages/dropdowns/dropdowns.ka-GE.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: სია ცარიელია

--- a/messages/dropdowns/dropdowns.nb-NO.yml
+++ b/messages/dropdowns/dropdowns.nb-NO.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.nb-NO.yml
+++ b/messages/dropdowns/dropdowns.nb-NO.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.nl-BE.yml
+++ b/messages/dropdowns/dropdowns.nl-BE.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.nl-BE.yml
+++ b/messages/dropdowns/dropdowns.nl-BE.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.nl-NL.yml
+++ b/messages/dropdowns/dropdowns.nl-NL.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.nl-NL.yml
+++ b/messages/dropdowns/dropdowns.nl-NL.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.pl-PL.yml
+++ b/messages/dropdowns/dropdowns.pl-PL.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.pl-PL.yml
+++ b/messages/dropdowns/dropdowns.pl-PL.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.pt-BR.yml
+++ b/messages/dropdowns/dropdowns.pt-BR.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.pt-BR.yml
+++ b/messages/dropdowns/dropdowns.pt-BR.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.pt-PT.yml
+++ b/messages/dropdowns/dropdowns.pt-PT.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.pt-PT.yml
+++ b/messages/dropdowns/dropdowns.pt-PT.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.ro-RO.yml
+++ b/messages/dropdowns/dropdowns.ro-RO.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.ro-RO.yml
+++ b/messages/dropdowns/dropdowns.ro-RO.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.ru-RU.yml
+++ b/messages/dropdowns/dropdowns.ru-RU.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.ru-RU.yml
+++ b/messages/dropdowns/dropdowns.ru-RU.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.sk-SK.yml
+++ b/messages/dropdowns/dropdowns.sk-SK.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Nenašli sa žiadne údaje

--- a/messages/dropdowns/dropdowns.sk-SK.yml
+++ b/messages/dropdowns/dropdowns.sk-SK.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.sv-SE.yml
+++ b/messages/dropdowns/dropdowns.sv-SE.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.sv-SE.yml
+++ b/messages/dropdowns/dropdowns.sv-SE.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.tr-TR.yml
+++ b/messages/dropdowns/dropdowns.tr-TR.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: Veri bulunamadı

--- a/messages/dropdowns/dropdowns.tr-TR.yml
+++ b/messages/dropdowns/dropdowns.tr-TR.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.uk-UA.yml
+++ b/messages/dropdowns/dropdowns.uk-UA.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.uk-UA.yml
+++ b/messages/dropdowns/dropdowns.uk-UA.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.zh-CN.yml
+++ b/messages/dropdowns/dropdowns.zh-CN.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.zh-CN.yml
+++ b/messages/dropdowns/dropdowns.zh-CN.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.zh-HK.yml
+++ b/messages/dropdowns/dropdowns.zh-HK.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.zh-HK.yml
+++ b/messages/dropdowns/dropdowns.zh-HK.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/dropdowns/dropdowns.zh-TW.yml
+++ b/messages/dropdowns/dropdowns.zh-TW.yml
@@ -70,6 +70,15 @@ kendo:
     # The text of the popup filter input aria label
     filterInputLabel: Filter
 
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel
+
+    # The text displayed for the check-all checkbox
+    checkAllText: Check all
+
   multicolumncombobox:
     # The text displayed in the popup when there are no items
     noDataText: No data found

--- a/messages/dropdowns/dropdowns.zh-TW.yml
+++ b/messages/dropdowns/dropdowns.zh-TW.yml
@@ -89,3 +89,9 @@ kendo:
 
     # The text of the popup label
     popupLabel: Options list
+
+    # The text of the Apply button in the action sheet
+    applyButton: Apply
+
+    # The text of the Cancel button in the action sheet
+    cancelButton: Cancel

--- a/messages/stepper/stepper.ar.yml
+++ b/messages/stepper/stepper.ar.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.bg-BG.yml
+++ b/messages/stepper/stepper.bg-BG.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.cs-CZ.yml
+++ b/messages/stepper/stepper.cs-CZ.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.da-DK.yml
+++ b/messages/stepper/stepper.da-DK.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.de-AT.yml
+++ b/messages/stepper/stepper.de-AT.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.de-CH.yml
+++ b/messages/stepper/stepper.de-CH.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.de-DE.yml
+++ b/messages/stepper/stepper.de-DE.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.de-LI.yml
+++ b/messages/stepper/stepper.de-LI.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.en-AU.yml
+++ b/messages/stepper/stepper.en-AU.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.en-CA.yml
+++ b/messages/stepper/stepper.en-CA.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.en-GB.yml
+++ b/messages/stepper/stepper.en-GB.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.en-US.yml
+++ b/messages/stepper/stepper.en-US.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-AR.yml
+++ b/messages/stepper/stepper.es-AR.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-BO.yml
+++ b/messages/stepper/stepper.es-BO.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-CL.yml
+++ b/messages/stepper/stepper.es-CL.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-CO.yml
+++ b/messages/stepper/stepper.es-CO.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-CR.yml
+++ b/messages/stepper/stepper.es-CR.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-DO.yml
+++ b/messages/stepper/stepper.es-DO.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-EC.yml
+++ b/messages/stepper/stepper.es-EC.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-ES.yml
+++ b/messages/stepper/stepper.es-ES.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-GT.yml
+++ b/messages/stepper/stepper.es-GT.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-HN.yml
+++ b/messages/stepper/stepper.es-HN.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-MX.yml
+++ b/messages/stepper/stepper.es-MX.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-NI.yml
+++ b/messages/stepper/stepper.es-NI.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-PA.yml
+++ b/messages/stepper/stepper.es-PA.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-PE.yml
+++ b/messages/stepper/stepper.es-PE.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-PR.yml
+++ b/messages/stepper/stepper.es-PR.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-PY.yml
+++ b/messages/stepper/stepper.es-PY.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-US.yml
+++ b/messages/stepper/stepper.es-US.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-UY.yml
+++ b/messages/stepper/stepper.es-UY.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.es-VE.yml
+++ b/messages/stepper/stepper.es-VE.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fa-IR.yml
+++ b/messages/stepper/stepper.fa-IR.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fi-FI.yml
+++ b/messages/stepper/stepper.fi-FI.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-BE.yml
+++ b/messages/stepper/stepper.fr-BE.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-CA.yml
+++ b/messages/stepper/stepper.fr-CA.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-CD.yml
+++ b/messages/stepper/stepper.fr-CD.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-CH.yml
+++ b/messages/stepper/stepper.fr-CH.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-CI.yml
+++ b/messages/stepper/stepper.fr-CI.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-CM.yml
+++ b/messages/stepper/stepper.fr-CM.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-FR.yml
+++ b/messages/stepper/stepper.fr-FR.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-HT.yml
+++ b/messages/stepper/stepper.fr-HT.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-LU.yml
+++ b/messages/stepper/stepper.fr-LU.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-MA.yml
+++ b/messages/stepper/stepper.fr-MA.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-MC.yml
+++ b/messages/stepper/stepper.fr-MC.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-ML.yml
+++ b/messages/stepper/stepper.fr-ML.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.fr-SN.yml
+++ b/messages/stepper/stepper.fr-SN.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.he-IL.yml
+++ b/messages/stepper/stepper.he-IL.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.hy-AM.yml
+++ b/messages/stepper/stepper.hy-AM.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.it-CH.yml
+++ b/messages/stepper/stepper.it-CH.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.it-IT.yml
+++ b/messages/stepper/stepper.it-IT.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.ja-JP.yml
+++ b/messages/stepper/stepper.ja-JP.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.ka-GE.yml
+++ b/messages/stepper/stepper.ka-GE.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.nb-NO.yml
+++ b/messages/stepper/stepper.nb-NO.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.nl-BE.yml
+++ b/messages/stepper/stepper.nl-BE.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.nl-NL.yml
+++ b/messages/stepper/stepper.nl-NL.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.pl-PL.yml
+++ b/messages/stepper/stepper.pl-PL.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.pt-BR.yml
+++ b/messages/stepper/stepper.pt-BR.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.pt-PT.yml
+++ b/messages/stepper/stepper.pt-PT.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.ro-RO.yml
+++ b/messages/stepper/stepper.ro-RO.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.ru-RU.yml
+++ b/messages/stepper/stepper.ru-RU.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.sk-SK.yml
+++ b/messages/stepper/stepper.sk-SK.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.sv-SE.yml
+++ b/messages/stepper/stepper.sv-SE.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.tr-TR.yml
+++ b/messages/stepper/stepper.tr-TR.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.uk-UA.yml
+++ b/messages/stepper/stepper.uk-UA.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.zh-CN.yml
+++ b/messages/stepper/stepper.zh-CN.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.zh-HK.yml
+++ b/messages/stepper/stepper.zh-HK.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional

--- a/messages/stepper/stepper.zh-TW.yml
+++ b/messages/stepper/stepper.zh-TW.yml
@@ -1,3 +1,4 @@
-
+kendo:
+  stepper:
     # The text for the optional segment of the step label.
     optional: Optional


### PR DESCRIPTION
stepper was missing the initial `kendo.stepper` path at the beginning of the file.
multiselecttree was missing `applyButton`, `cancelButton` and  `checkAllText`
multiselect was missing `applyButton` and  `cancelButton`