### PR TITLE
fix: update dynamic placeholder syntax

### DIFF
--- a/messages/dropdowns/dropdowns.ar.yml
+++ b/messages/dropdowns/dropdowns.ar.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.bg-BG.yml
+++ b/messages/dropdowns/dropdowns.bg-BG.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Отмени
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Използвай "{customValue}"
+    useCustomValueText: Използвай "[[customValue]]"

--- a/messages/dropdowns/dropdowns.cs-CZ.yml
+++ b/messages/dropdowns/dropdowns.cs-CZ.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.da-DK.yml
+++ b/messages/dropdowns/dropdowns.da-DK.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.de-AT.yml
+++ b/messages/dropdowns/dropdowns.de-AT.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Abbrechen
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.de-CH.yml
+++ b/messages/dropdowns/dropdowns.de-CH.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Abbrechen
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.de-DE.yml
+++ b/messages/dropdowns/dropdowns.de-DE.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Abbrechen
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.de-LI.yml
+++ b/messages/dropdowns/dropdowns.de-LI.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.en-AU.yml
+++ b/messages/dropdowns/dropdowns.en-AU.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.en-CA.yml
+++ b/messages/dropdowns/dropdowns.en-CA.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.en-GB.yml
+++ b/messages/dropdowns/dropdowns.en-GB.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.en-US.yml
+++ b/messages/dropdowns/dropdowns.en-US.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-AR.yml
+++ b/messages/dropdowns/dropdowns.es-AR.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-BO.yml
+++ b/messages/dropdowns/dropdowns.es-BO.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-CL.yml
+++ b/messages/dropdowns/dropdowns.es-CL.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-CO.yml
+++ b/messages/dropdowns/dropdowns.es-CO.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-CR.yml
+++ b/messages/dropdowns/dropdowns.es-CR.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-DO.yml
+++ b/messages/dropdowns/dropdowns.es-DO.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-EC.yml
+++ b/messages/dropdowns/dropdowns.es-EC.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-ES.yml
+++ b/messages/dropdowns/dropdowns.es-ES.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancelar
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-GT.yml
+++ b/messages/dropdowns/dropdowns.es-GT.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-HN.yml
+++ b/messages/dropdowns/dropdowns.es-HN.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-MX.yml
+++ b/messages/dropdowns/dropdowns.es-MX.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-NI.yml
+++ b/messages/dropdowns/dropdowns.es-NI.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-PA.yml
+++ b/messages/dropdowns/dropdowns.es-PA.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-PE.yml
+++ b/messages/dropdowns/dropdowns.es-PE.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-PR.yml
+++ b/messages/dropdowns/dropdowns.es-PR.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-PY.yml
+++ b/messages/dropdowns/dropdowns.es-PY.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-US.yml
+++ b/messages/dropdowns/dropdowns.es-US.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-UY.yml
+++ b/messages/dropdowns/dropdowns.es-UY.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.es-VE.yml
+++ b/messages/dropdowns/dropdowns.es-VE.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fa-IR.yml
+++ b/messages/dropdowns/dropdowns.fa-IR.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fi-FI.yml
+++ b/messages/dropdowns/dropdowns.fi-FI.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-BE.yml
+++ b/messages/dropdowns/dropdowns.fr-BE.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-CA.yml
+++ b/messages/dropdowns/dropdowns.fr-CA.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-CD.yml
+++ b/messages/dropdowns/dropdowns.fr-CD.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-CH.yml
+++ b/messages/dropdowns/dropdowns.fr-CH.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-CI.yml
+++ b/messages/dropdowns/dropdowns.fr-CI.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-CM.yml
+++ b/messages/dropdowns/dropdowns.fr-CM.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-FR.yml
+++ b/messages/dropdowns/dropdowns.fr-FR.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-HT.yml
+++ b/messages/dropdowns/dropdowns.fr-HT.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-LU.yml
+++ b/messages/dropdowns/dropdowns.fr-LU.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-MA.yml
+++ b/messages/dropdowns/dropdowns.fr-MA.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-MC.yml
+++ b/messages/dropdowns/dropdowns.fr-MC.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-ML.yml
+++ b/messages/dropdowns/dropdowns.fr-ML.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.fr-SN.yml
+++ b/messages/dropdowns/dropdowns.fr-SN.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.he-IL.yml
+++ b/messages/dropdowns/dropdowns.he-IL.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.hy-AM.yml
+++ b/messages/dropdowns/dropdowns.hy-AM.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.it-CH.yml
+++ b/messages/dropdowns/dropdowns.it-CH.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.it-IT.yml
+++ b/messages/dropdowns/dropdowns.it-IT.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.ja-JP.yml
+++ b/messages/dropdowns/dropdowns.ja-JP.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.ka-GE.yml
+++ b/messages/dropdowns/dropdowns.ka-GE.yml
@@ -105,4 +105,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.nb-NO.yml
+++ b/messages/dropdowns/dropdowns.nb-NO.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.nl-BE.yml
+++ b/messages/dropdowns/dropdowns.nl-BE.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.nl-NL.yml
+++ b/messages/dropdowns/dropdowns.nl-NL.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.pl-PL.yml
+++ b/messages/dropdowns/dropdowns.pl-PL.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.pt-BR.yml
+++ b/messages/dropdowns/dropdowns.pt-BR.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.pt-PT.yml
+++ b/messages/dropdowns/dropdowns.pt-PT.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.ro-RO.yml
+++ b/messages/dropdowns/dropdowns.ro-RO.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.ru-RU.yml
+++ b/messages/dropdowns/dropdowns.ru-RU.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.sk-SK.yml
+++ b/messages/dropdowns/dropdowns.sk-SK.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.sv-SE.yml
+++ b/messages/dropdowns/dropdowns.sv-SE.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.tr-TR.yml
+++ b/messages/dropdowns/dropdowns.tr-TR.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.uk-UA.yml
+++ b/messages/dropdowns/dropdowns.uk-UA.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.zh-CN.yml
+++ b/messages/dropdowns/dropdowns.zh-CN.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.zh-HK.yml
+++ b/messages/dropdowns/dropdowns.zh-HK.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/dropdowns/dropdowns.zh-TW.yml
+++ b/messages/dropdowns/dropdowns.zh-TW.yml
@@ -106,4 +106,4 @@ kendo:
     cancelButton: Cancel
 
     # The text displayed when the user types a custom value that is not in the list of options.
-    useCustomValueText: Use "{customValue}"
+    useCustomValueText: Use "[[customValue]]"

--- a/messages/editor/editor.ar.yml
+++ b/messages/editor/editor.ar.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.bg-BG.yml
+++ b/messages/editor/editor.bg-BG.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Раздели клетка
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Създай таблица {rows} {x} {columns}'
+    insertTableHint: 'Създай таблица [[rows]] [[x]] [[columns]]'

--- a/messages/editor/editor.cs-CZ.yml
+++ b/messages/editor/editor.cs-CZ.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.da-DK.yml
+++ b/messages/editor/editor.da-DK.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.de-AT.yml
+++ b/messages/editor/editor.de-AT.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Zellen separieren
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.de-CH.yml
+++ b/messages/editor/editor.de-CH.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Zellen separieren
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.de-DE.yml
+++ b/messages/editor/editor.de-DE.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Zellen separieren
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.de-LI.yml
+++ b/messages/editor/editor.de-LI.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.en-AU.yml
+++ b/messages/editor/editor.en-AU.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.en-CA.yml
+++ b/messages/editor/editor.en-CA.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.en-GB.yml
+++ b/messages/editor/editor.en-GB.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.en-US.yml
+++ b/messages/editor/editor.en-US.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-AR.yml
+++ b/messages/editor/editor.es-AR.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-BO.yml
+++ b/messages/editor/editor.es-BO.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-CL.yml
+++ b/messages/editor/editor.es-CL.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-CO.yml
+++ b/messages/editor/editor.es-CO.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-CR.yml
+++ b/messages/editor/editor.es-CR.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-DO.yml
+++ b/messages/editor/editor.es-DO.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-EC.yml
+++ b/messages/editor/editor.es-EC.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-ES.yml
+++ b/messages/editor/editor.es-ES.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-GT.yml
+++ b/messages/editor/editor.es-GT.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-HN.yml
+++ b/messages/editor/editor.es-HN.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-MX.yml
+++ b/messages/editor/editor.es-MX.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-NI.yml
+++ b/messages/editor/editor.es-NI.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-PA.yml
+++ b/messages/editor/editor.es-PA.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-PE.yml
+++ b/messages/editor/editor.es-PE.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-PR.yml
+++ b/messages/editor/editor.es-PR.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-PY.yml
+++ b/messages/editor/editor.es-PY.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-US.yml
+++ b/messages/editor/editor.es-US.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-UY.yml
+++ b/messages/editor/editor.es-UY.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.es-VE.yml
+++ b/messages/editor/editor.es-VE.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fi-FI.yml
+++ b/messages/editor/editor.fi-FI.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-BE.yml
+++ b/messages/editor/editor.fr-BE.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-CA.yml
+++ b/messages/editor/editor.fr-CA.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-CD.yml
+++ b/messages/editor/editor.fr-CD.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-CH.yml
+++ b/messages/editor/editor.fr-CH.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-CI.yml
+++ b/messages/editor/editor.fr-CI.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-CM.yml
+++ b/messages/editor/editor.fr-CM.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-FR.yml
+++ b/messages/editor/editor.fr-FR.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-HT.yml
+++ b/messages/editor/editor.fr-HT.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-LU.yml
+++ b/messages/editor/editor.fr-LU.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-MA.yml
+++ b/messages/editor/editor.fr-MA.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-MC.yml
+++ b/messages/editor/editor.fr-MC.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-ML.yml
+++ b/messages/editor/editor.fr-ML.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.fr-SN.yml
+++ b/messages/editor/editor.fr-SN.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.he-IL.yml
+++ b/messages/editor/editor.he-IL.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.hy-AM.yml
+++ b/messages/editor/editor.hy-AM.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.it-CH.yml
+++ b/messages/editor/editor.it-CH.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.it-IT.yml
+++ b/messages/editor/editor.it-IT.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Dividi le celle
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.ja-JP.yml
+++ b/messages/editor/editor.ja-JP.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.ka-GE.yml
+++ b/messages/editor/editor.ka-GE.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.nb-NO.yml
+++ b/messages/editor/editor.nb-NO.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.nl-BE.yml
+++ b/messages/editor/editor.nl-BE.yml
@@ -162,4 +162,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.nl-NL.yml
+++ b/messages/editor/editor.nl-NL.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.pl-PL.yml
+++ b/messages/editor/editor.pl-PL.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.pt-BR.yml
+++ b/messages/editor/editor.pt-BR.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.pt-PT.yml
+++ b/messages/editor/editor.pt-PT.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.ro-RO.yml
+++ b/messages/editor/editor.ro-RO.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.ru-RU.yml
+++ b/messages/editor/editor.ru-RU.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.sk-SK.yml
+++ b/messages/editor/editor.sk-SK.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Rozdeliť bunku
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.sv-SE.yml
+++ b/messages/editor/editor.sv-SE.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.tr-TR.yml
+++ b/messages/editor/editor.tr-TR.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.uk-UA.yml
+++ b/messages/editor/editor.uk-UA.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.zh-CN.yml
+++ b/messages/editor/editor.zh-CN.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.zh-HK.yml
+++ b/messages/editor/editor.zh-HK.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/editor/editor.zh-TW.yml
+++ b/messages/editor/editor.zh-TW.yml
@@ -163,4 +163,4 @@ kendo:
     splitCell: Split cell
 
     # The caption for the hint in the insert table tool.
-    insertTableHint: 'Create a {rows} {x} {columns} table'
+    insertTableHint: 'Create a [[rows]] [[x]] [[columns]] table'

--- a/messages/grid/grid.ar.yml
+++ b/messages/grid/grid.ar.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.bg-BG.yml
+++ b/messages/grid/grid.bg-BG.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Несортирано
 
     # The label of the filter row and menu inputs
-    filterInputLabel: 'Филтър за {columnName}'
+    filterInputLabel: 'Филтър за [[columnName]]'
 
     # The title of the filter menu icon
-    filterMenuTitle: 'Меню за филтриране на {columnName}'
+    filterMenuTitle: 'Меню за филтриране на [[columnName]]'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: 'Оператори за филтриране на {columnName}'
+    filterMenuOperatorsDropDownLabel: 'Оператори за филтриране на [[columnName]]'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: 'Логика за филтриране на {columnName}'
+    filterMenuLogicDropDownLabel: 'Логика за филтриране на [[columnName]]'
 
     # The title of the column menu icon
-    columnMenu: 'Меню за настройки на колоната {columnName}'
+    columnMenu: 'Меню за настройки на колоната [[columnName]]'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Селектирай реда
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Селектирай всички редове
 
     # The label of the Grid pager
-    pagerLabel: 'Навигация, страница {currentPage} от {totalPages}'
+    pagerLabel: 'Навигация, страница [[currentPage]] от [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Таблица с данни
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Избери всички редове
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Филтър оператори за {columnName}'
+    filterCellOperatorLabel: 'Филтър оператори за [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Булев филтър за {columnName}'
+    booleanFilterCellLabel: 'Булев филтър за [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Филтър
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Въведи номер на страница
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'Грешка от тип {errorName} при валидация на полето {fieldName}'
+    formValidationErrorText: 'Грешка от тип [[errorName]] при валидация на полето [[fieldName]]'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Моля потвърдете
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Избери всички
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} избрани елементи'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] избрани елементи'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Селекцията може да се приложи само когато е включена съответната грид опция."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Селекцията може да се приложи само когато режимът за селекция на клетки е включен."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} избрани колони'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] избрани колони'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Избери всички"

--- a/messages/grid/grid.cs-CZ.yml
+++ b/messages/grid/grid.cs-CZ.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.da-DK.yml
+++ b/messages/grid/grid.da-DK.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.de-AT.yml
+++ b/messages/grid/grid.de-AT.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Nicht sortiert
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menü'
+    filterMenuTitle: '[[columnName]] Filter Menü'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operatoren'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operatoren'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logik'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logik'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Spaltenmenü'
+    columnMenu: '[[columnName]] Spaltenmenü'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Zeile auswählen
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Alle Zeilen auswählen
 
     # The label of the Grid pager
-    pagerLabel: 'Zeilennavigation, Seite {currentPage} von {totalPages}'
+    pagerLabel: 'Zeilennavigation, Seite [[currentPage]] von [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Datentabelle
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Alle Zeilen auswählen
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filterzelle Operatoren für {columnName}'
+    filterCellOperatorLabel: 'Filterzelle Operatoren für [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolesche Filterzelle für {columnName}'
+    booleanFilterCellLabel: 'Boolesche Filterzelle für [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.de-CH.yml
+++ b/messages/grid/grid.de-CH.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Nicht sortiert
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menü'
+    filterMenuTitle: '[[columnName]] Filter Menü'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operatoren'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operatoren'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logik'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logik'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Spaltenmenü'
+    columnMenu: '[[columnName]] Spaltenmenü'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Zeile auswählen
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Alle Zeilen auswählen
 
     # The label of the Grid pager
-    pagerLabel: 'Zeilennavigation, Seite {currentPage} von {totalPages}'
+    pagerLabel: 'Zeilennavigation, Seite [[currentPage]] von [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Datentabelle
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Alle Zeilen auswählen
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filterzelle Operatoren für {columnName}'
+    filterCellOperatorLabel: 'Filterzelle Operatoren für [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolesche Filterzelle für {columnName}'
+    booleanFilterCellLabel: 'Boolesche Filterzelle für [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.de-DE.yml
+++ b/messages/grid/grid.de-DE.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Nicht sortiert
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menü'
+    filterMenuTitle: '[[columnName]] Filter Menü'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operatoren'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operatoren'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logik'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logik'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Spaltenmenü'
+    columnMenu: '[[columnName]] Spaltenmenü'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Zeile auswählen
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Alle Zeilen auswählen
 
     # The label of the Grid pager
-    pagerLabel: 'Zeilennavigation, Seite {currentPage} von {totalPages}'
+    pagerLabel: 'Zeilennavigation, Seite [[currentPage]] von [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Datentabelle
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Alle Zeilen auswählen
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filterzelle Operatoren für {columnName}'
+    filterCellOperatorLabel: 'Filterzelle Operatoren für [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolesche Filterzelle für {columnName}'
+    booleanFilterCellLabel: 'Boolesche Filterzelle für [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.de-LI.yml
+++ b/messages/grid/grid.de-LI.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Spaltenmenü'
+    columnMenu: '[[columnName]] Spaltenmenü'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.en-AU.yml
+++ b/messages/grid/grid.en-AU.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.en-CA.yml
+++ b/messages/grid/grid.en-CA.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.en-GB.yml
+++ b/messages/grid/grid.en-GB.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.en-US.yml
+++ b/messages/grid/grid.en-US.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-AR.yml
+++ b/messages/grid/grid.es-AR.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-BO.yml
+++ b/messages/grid/grid.es-BO.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-CL.yml
+++ b/messages/grid/grid.es-CL.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-CO.yml
+++ b/messages/grid/grid.es-CO.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-CR.yml
+++ b/messages/grid/grid.es-CR.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-DO.yml
+++ b/messages/grid/grid.es-DO.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-EC.yml
+++ b/messages/grid/grid.es-EC.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-ES.yml
+++ b/messages/grid/grid.es-ES.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: No ordenado
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filtro'
+    filterInputLabel: '[[columnName]] Filtro'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Menú de Filtro'
+    filterMenuTitle: '[[columnName]] Menú de Filtro'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Operadores de Filtro'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Operadores de Filtro'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Lógica de Filtro'
+    filterMenuLogicDropDownLabel: '[[columnName]] Lógica de Filtro'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menú de Columna'
+    columnMenu: '[[columnName]] Menú de Columna'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Seleccionar Fila
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Seleccionar Todas las Filas
 
     # The label of the Grid pager
-    pagerLabel: 'Navegación de página, página {currentPage} de {totalPages}'
+    pagerLabel: 'Navegación de página, página [[currentPage]] de [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Tabla de datos
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Seleccionar todas las filas
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Operadores de celda de filtro para {columnName}'
+    filterCellOperatorLabel: 'Operadores de celda de filtro para [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Celda de filtro booleano para {columnName}'
+    booleanFilterCellLabel: 'Celda de filtro booleano para [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filtro
@@ -260,7 +260,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -359,7 +359,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -371,7 +371,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-GT.yml
+++ b/messages/grid/grid.es-GT.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-HN.yml
+++ b/messages/grid/grid.es-HN.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-MX.yml
+++ b/messages/grid/grid.es-MX.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-NI.yml
+++ b/messages/grid/grid.es-NI.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-PA.yml
+++ b/messages/grid/grid.es-PA.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-PE.yml
+++ b/messages/grid/grid.es-PE.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-PR.yml
+++ b/messages/grid/grid.es-PR.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-PY.yml
+++ b/messages/grid/grid.es-PY.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-US.yml
+++ b/messages/grid/grid.es-US.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-UY.yml
+++ b/messages/grid/grid.es-UY.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.es-VE.yml
+++ b/messages/grid/grid.es-VE.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fa-IR.yml
+++ b/messages/grid/grid.fa-IR.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: مرتب نشده
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fi-FI.yml
+++ b/messages/grid/grid.fi-FI.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-BE.yml
+++ b/messages/grid/grid.fr-BE.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-CA.yml
+++ b/messages/grid/grid.fr-CA.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-CD.yml
+++ b/messages/grid/grid.fr-CD.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-CH.yml
+++ b/messages/grid/grid.fr-CH.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-CI.yml
+++ b/messages/grid/grid.fr-CI.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-CM.yml
+++ b/messages/grid/grid.fr-CM.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-FR.yml
+++ b/messages/grid/grid.fr-FR.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-HT.yml
+++ b/messages/grid/grid.fr-HT.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-LU.yml
+++ b/messages/grid/grid.fr-LU.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-MA.yml
+++ b/messages/grid/grid.fr-MA.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-MC.yml
+++ b/messages/grid/grid.fr-MC.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-ML.yml
+++ b/messages/grid/grid.fr-ML.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.fr-SN.yml
+++ b/messages/grid/grid.fr-SN.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.he-IL.yml
+++ b/messages/grid/grid.he-IL.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.hy-AM.yml
+++ b/messages/grid/grid.hy-AM.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.it-CH.yml
+++ b/messages/grid/grid.it-CH.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Non ordinato
 
     # The label of the filter row and menu inputs
-    filterInputLabel: 'Filtro {columnName}'
+    filterInputLabel: 'Filtro [[columnName]]'
 
     # The title of the filter menu icon
-    filterMenuTitle: 'Menù filtro {columnName}'
+    filterMenuTitle: 'Menù filtro [[columnName]]'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: 'Operatori filtro per {columnName}'
+    filterMenuOperatorsDropDownLabel: 'Operatori filtro per [[columnName]]'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: 'Filtri logici per {columnName}'
+    filterMenuLogicDropDownLabel: 'Filtri logici per [[columnName]]'
 
     # The title of the column menu icon
-    columnMenu: 'Menù colonna {columnName}'
+    columnMenu: 'Menù colonna [[columnName]]'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Seleziona la riga
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Seleziona tutte le righe
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, pagina {currentPage} di {totalPages}'
+    pagerLabel: 'Page navigation, pagina [[currentPage]] di [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Tabella dati
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.it-IT.yml
+++ b/messages/grid/grid.it-IT.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Non ordinato
 
     # The label of the filter row and menu inputs
-    filterInputLabel: 'Filtro {columnName}'
+    filterInputLabel: 'Filtro [[columnName]]'
 
     # The title of the filter menu icon
-    filterMenuTitle: 'Menù filtro {columnName}'
+    filterMenuTitle: 'Menù filtro [[columnName]]'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: 'Operatori filtro per {columnName}'
+    filterMenuOperatorsDropDownLabel: 'Operatori filtro per [[columnName]]'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: 'Filtri logici per {columnName}'
+    filterMenuLogicDropDownLabel: 'Filtri logici per [[columnName]]'
 
     # The title of the column menu icon
-    columnMenu: 'Menù colonna {columnName}'
+    columnMenu: 'Menù colonna [[columnName]]'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Seleziona la riga
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Seleziona tutte le righe
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, pagina {currentPage} di {totalPages}'
+    pagerLabel: 'Page navigation, pagina [[currentPage]] di [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Tabella dati
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.ja-JP.yml
+++ b/messages/grid/grid.ja-JP.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.ka-GE.yml
+++ b/messages/grid/grid.ka-GE.yml
@@ -167,19 +167,19 @@ kendo:
     sortedDefault: არასორტირებული
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} ფილტრი'
+    filterInputLabel: '[[columnName]] ფილტრი'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} ფილტრი'
+    filterMenuTitle: '[[columnName]] ფილტრი'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} ფილტრი'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] ფილტრი'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} ფილტრი'
+    filterMenuLogicDropDownLabel: '[[columnName]] ფილტრი'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} მენიუ'
+    columnMenu: '[[columnName]] მენიუ'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: მონიშნე სტრიქონი
@@ -188,7 +188,7 @@ kendo:
     selectAllCheckboxLabel: მონიშნე ყველა
 
     # The label of the Grid pager
-    pagerLabel: 'გვერდი {currentPage} - {totalPages}-დან'
+    pagerLabel: 'გვერდი [[currentPage]] - [[totalPages]]-დან'
 
     # The Grid aria-label
     gridLabel: ცხრილი
@@ -230,10 +230,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -254,7 +254,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -353,7 +353,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -365,7 +365,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.nb-NO.yml
+++ b/messages/grid/grid.nb-NO.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.nl-BE.yml
+++ b/messages/grid/grid.nl-BE.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.nl-NL.yml
+++ b/messages/grid/grid.nl-NL.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.pl-PL.yml
+++ b/messages/grid/grid.pl-PL.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.pt-BR.yml
+++ b/messages/grid/grid.pt-BR.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.pt-PT.yml
+++ b/messages/grid/grid.pt-PT.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -236,10 +236,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -260,7 +260,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -359,7 +359,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -371,7 +371,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.ro-RO.yml
+++ b/messages/grid/grid.ro-RO.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.ru-RU.yml
+++ b/messages/grid/grid.ru-RU.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Сортировка сброшена
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.sk-SK.yml
+++ b/messages/grid/grid.sk-SK.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Neusporiadané
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} filter'
+    filterInputLabel: '[[columnName]] filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} filtrovacie menu'
+    filterMenuTitle: '[[columnName]] filtrovacie menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} filtrovacie operátory'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] filtrovacie operátory'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} filtrovacia logika'
+    filterMenuLogicDropDownLabel: '[[columnName]] filtrovacia logika'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} ponuka stĺpca'
+    columnMenu: '[[columnName]] ponuka stĺpca'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Označiť riadok
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Označiť všetky riadky
 
     # The label of the Grid pager
-    pagerLabel: 'Stránkovacia navigácia, strana {currentPage} z {totalPages}'
+    pagerLabel: 'Stránkovacia navigácia, strana [[currentPage]] z [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Dátová tabuľka
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.sv-SE.yml
+++ b/messages/grid/grid.sv-SE.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Ej sorterad
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operatorer'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operatorer'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logik'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logik'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Kolumn Menu'
+    columnMenu: '[[columnName]] Kolumn Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Välj rad
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Välj alla rader
 
     # The label of the Grid pager
-    pagerLabel: 'Sidnavigering, sida {currentPage} av {totalPages}'
+    pagerLabel: 'Sidnavigering, sida [[currentPage]] av [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data tabell
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.tr-TR.yml
+++ b/messages/grid/grid.tr-TR.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Sırasız
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filtresi'
+    filterInputLabel: '[[columnName]] Filtresi'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filtre Menüsü'
+    filterMenuTitle: '[[columnName]] Filtre Menüsü'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filtre Operatörleri'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filtre Operatörleri'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filtre işlemi'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filtre işlemi'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} menüsü'
+    columnMenu: '[[columnName]] menüsü'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Satır seç
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Tüm satırları seç
 
     # The label of the Grid pager
-    pagerLabel: '{currentPage} / {totalPages} sayfa'
+    pagerLabel: '[[currentPage]] / [[totalPages]] sayfa'
 
     # The Grid aria-label
     gridLabel: Veri tablosu
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.uk-UA.yml
+++ b/messages/grid/grid.uk-UA.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.zh-CN.yml
+++ b/messages/grid/grid.zh-CN.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.zh-HK.yml
+++ b/messages/grid/grid.zh-HK.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/grid/grid.zh-TW.yml
+++ b/messages/grid/grid.zh-TW.yml
@@ -169,19 +169,19 @@ kendo:
     sortedDefault: Not sorted
 
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The labels of the checkbox column checkboxes
     selectionCheckboxLabel: Select Row
@@ -190,7 +190,7 @@ kendo:
     selectAllCheckboxLabel: Select All Rows
 
     # The label of the Grid pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The Grid aria-label
     gridLabel: Data table
@@ -235,10 +235,10 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The title for the column menu Filter tab.
     columnMenuFilterTabTitle: Filter
@@ -259,7 +259,7 @@ kendo:
     pagerInputLabel: Type a page number
 
     # The default text of a form validation error when using external editing
-    formValidationErrorText: 'The {fieldName} field has {errorName} validation error'
+    formValidationErrorText: 'The [[fieldName]] field has [[errorName]] validation error'
 
     # The title of the remove item confirmation Dialog
     removeConfirmationDialogTitle: Please confirm
@@ -358,7 +358,7 @@ kendo:
     multiCheckboxFilterSelectAllLabel: Select all
 
     # The text for the multi-checkbox filter selected items count
-    multiCheckboxFilterSelectedItemsCount: '{selectedItemsCount} selected items'
+    multiCheckboxFilterSelectedItemsCount: '[[selectedItemsCount]] selected items'
     
     # The message shown when AI selection requires the Grid selectable option
     aiAssistantSelectionNotEnabled: "Selection can be applied only when the Grid selectable option is enabled."
@@ -370,7 +370,7 @@ kendo:
     aiAssistantSelectionCellModeRequired: "Selection can be applied only when cell selection mode is enabled."
 
     # The text displayed in the Column Chooser for the number of selected columns
-    columnChooserSelectedColumnsCount: '{selectedColumnsCount} Selected items'
+    columnChooserSelectedColumnsCount: '[[selectedColumnsCount]] Selected items'
 
     # The text for the Select all checkbox in the Column Chooser
     columnChooserSelectAll: "Select all"

--- a/messages/otpinput/otpinput.ar.yml
+++ b/messages/otpinput/otpinput.ar.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.bg-BG.yml
+++ b/messages/otpinput/otpinput.bg-BG.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Поле {currentInput} от {totalInputs}, текуща стойност {value}'
+    ariaLabel: 'Поле [[currentInput]] от [[totalInputs]], текуща стойност [[value]]'

--- a/messages/otpinput/otpinput.cs-CZ.yml
+++ b/messages/otpinput/otpinput.cs-CZ.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.da-DK.yml
+++ b/messages/otpinput/otpinput.da-DK.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.de-AT.yml
+++ b/messages/otpinput/otpinput.de-AT.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.de-CH.yml
+++ b/messages/otpinput/otpinput.de-CH.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.de-DE.yml
+++ b/messages/otpinput/otpinput.de-DE.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.de-LI.yml
+++ b/messages/otpinput/otpinput.de-LI.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.en-AU.yml
+++ b/messages/otpinput/otpinput.en-AU.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.en-CA.yml
+++ b/messages/otpinput/otpinput.en-CA.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.en-GB.yml
+++ b/messages/otpinput/otpinput.en-GB.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.en-US.yml
+++ b/messages/otpinput/otpinput.en-US.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-AR.yml
+++ b/messages/otpinput/otpinput.es-AR.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-BO.yml
+++ b/messages/otpinput/otpinput.es-BO.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-CL.yml
+++ b/messages/otpinput/otpinput.es-CL.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-CO.yml
+++ b/messages/otpinput/otpinput.es-CO.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-CR.yml
+++ b/messages/otpinput/otpinput.es-CR.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-DO.yml
+++ b/messages/otpinput/otpinput.es-DO.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-EC.yml
+++ b/messages/otpinput/otpinput.es-EC.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-ES.yml
+++ b/messages/otpinput/otpinput.es-ES.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-GT.yml
+++ b/messages/otpinput/otpinput.es-GT.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-HN.yml
+++ b/messages/otpinput/otpinput.es-HN.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-MX.yml
+++ b/messages/otpinput/otpinput.es-MX.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-NI.yml
+++ b/messages/otpinput/otpinput.es-NI.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-PA.yml
+++ b/messages/otpinput/otpinput.es-PA.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-PE.yml
+++ b/messages/otpinput/otpinput.es-PE.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-PR.yml
+++ b/messages/otpinput/otpinput.es-PR.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-PY.yml
+++ b/messages/otpinput/otpinput.es-PY.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-US.yml
+++ b/messages/otpinput/otpinput.es-US.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-UY.yml
+++ b/messages/otpinput/otpinput.es-UY.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.es-VE.yml
+++ b/messages/otpinput/otpinput.es-VE.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fa-IR.yml
+++ b/messages/otpinput/otpinput.fa-IR.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fi-FI.yml
+++ b/messages/otpinput/otpinput.fi-FI.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-BE.yml
+++ b/messages/otpinput/otpinput.fr-BE.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-CA.yml
+++ b/messages/otpinput/otpinput.fr-CA.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-CD.yml
+++ b/messages/otpinput/otpinput.fr-CD.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-CH.yml
+++ b/messages/otpinput/otpinput.fr-CH.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-CI.yml
+++ b/messages/otpinput/otpinput.fr-CI.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-CM.yml
+++ b/messages/otpinput/otpinput.fr-CM.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-FR.yml
+++ b/messages/otpinput/otpinput.fr-FR.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-HT.yml
+++ b/messages/otpinput/otpinput.fr-HT.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-LU.yml
+++ b/messages/otpinput/otpinput.fr-LU.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-MA.yml
+++ b/messages/otpinput/otpinput.fr-MA.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-MC.yml
+++ b/messages/otpinput/otpinput.fr-MC.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-ML.yml
+++ b/messages/otpinput/otpinput.fr-ML.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.fr-SN.yml
+++ b/messages/otpinput/otpinput.fr-SN.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.he-IL.yml
+++ b/messages/otpinput/otpinput.he-IL.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.hy-AM.yml
+++ b/messages/otpinput/otpinput.hy-AM.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.it-CH.yml
+++ b/messages/otpinput/otpinput.it-CH.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.it-IT.yml
+++ b/messages/otpinput/otpinput.it-IT.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.ja-JP.yml
+++ b/messages/otpinput/otpinput.ja-JP.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.ka-GE.yml
+++ b/messages/otpinput/otpinput.ka-GE.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.nb-NO.yml
+++ b/messages/otpinput/otpinput.nb-NO.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.nl-BE.yml
+++ b/messages/otpinput/otpinput.nl-BE.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.nl-NL.yml
+++ b/messages/otpinput/otpinput.nl-NL.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.pl-PL.yml
+++ b/messages/otpinput/otpinput.pl-PL.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.pt-BR.yml
+++ b/messages/otpinput/otpinput.pt-BR.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.pt-PT.yml
+++ b/messages/otpinput/otpinput.pt-PT.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.ro-RO.yml
+++ b/messages/otpinput/otpinput.ro-RO.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.ru-RU.yml
+++ b/messages/otpinput/otpinput.ru-RU.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.sk-SK.yml
+++ b/messages/otpinput/otpinput.sk-SK.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.sv-SE.yml
+++ b/messages/otpinput/otpinput.sv-SE.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.tr-TR.yml
+++ b/messages/otpinput/otpinput.tr-TR.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.uk-UA.yml
+++ b/messages/otpinput/otpinput.uk-UA.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.zh-CN.yml
+++ b/messages/otpinput/otpinput.zh-CN.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.zh-HK.yml
+++ b/messages/otpinput/otpinput.zh-HK.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/otpinput/otpinput.zh-TW.yml
+++ b/messages/otpinput/otpinput.zh-TW.yml
@@ -1,4 +1,4 @@
 kendo:
   otpinput:
     # The value of the aria-label attribute of the input fields.
-    ariaLabel: 'Input {currentInput} of {totalInputs}, current value {value}'
+    ariaLabel: 'Input [[currentInput]] of [[totalInputs]], current value [[value]]'

--- a/messages/pivotgrid/pivotgrid.ar.yml
+++ b/messages/pivotgrid/pivotgrid.ar.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.bg-BG.yml
+++ b/messages/pivotgrid/pivotgrid.bg-BG.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Филтрирай
 
     # The label of the filter input
-    filterInputLabel: 'Филтър за {fields}'
+    filterInputLabel: 'Филтър за [[fields]]'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: 'Оператори за филтриране на {fields}'
+    filterOperatorsDropDownLabel: 'Оператори за филтриране на [[fields]]'
 
     # The text of the "equal" filter operator
     filterEqOperator: Е равно на

--- a/messages/pivotgrid/pivotgrid.cs-CZ.yml
+++ b/messages/pivotgrid/pivotgrid.cs-CZ.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.da-DK.yml
+++ b/messages/pivotgrid/pivotgrid.da-DK.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.de-AT.yml
+++ b/messages/pivotgrid/pivotgrid.de-AT.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operatoren'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operatoren'
 
     # The text of the "equal" filter operator
     filterEqOperator: ist gleich

--- a/messages/pivotgrid/pivotgrid.de-CH.yml
+++ b/messages/pivotgrid/pivotgrid.de-CH.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operatoren'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operatoren'
 
     # The text of the "equal" filter operator
     filterEqOperator: ist gleich

--- a/messages/pivotgrid/pivotgrid.de-DE.yml
+++ b/messages/pivotgrid/pivotgrid.de-DE.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operatoren'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operatoren'
 
     # The text of the "equal" filter operator
     filterEqOperator: ist gleich

--- a/messages/pivotgrid/pivotgrid.de-LI.yml
+++ b/messages/pivotgrid/pivotgrid.de-LI.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.en-AU.yml
+++ b/messages/pivotgrid/pivotgrid.en-AU.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.en-CA.yml
+++ b/messages/pivotgrid/pivotgrid.en-CA.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.en-GB.yml
+++ b/messages/pivotgrid/pivotgrid.en-GB.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.en-US.yml
+++ b/messages/pivotgrid/pivotgrid.en-US.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-AR.yml
+++ b/messages/pivotgrid/pivotgrid.es-AR.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-BO.yml
+++ b/messages/pivotgrid/pivotgrid.es-BO.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-CL.yml
+++ b/messages/pivotgrid/pivotgrid.es-CL.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-CO.yml
+++ b/messages/pivotgrid/pivotgrid.es-CO.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-CR.yml
+++ b/messages/pivotgrid/pivotgrid.es-CR.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-DO.yml
+++ b/messages/pivotgrid/pivotgrid.es-DO.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-EC.yml
+++ b/messages/pivotgrid/pivotgrid.es-EC.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-ES.yml
+++ b/messages/pivotgrid/pivotgrid.es-ES.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-GT.yml
+++ b/messages/pivotgrid/pivotgrid.es-GT.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-HN.yml
+++ b/messages/pivotgrid/pivotgrid.es-HN.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-MX.yml
+++ b/messages/pivotgrid/pivotgrid.es-MX.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-NI.yml
+++ b/messages/pivotgrid/pivotgrid.es-NI.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-PA.yml
+++ b/messages/pivotgrid/pivotgrid.es-PA.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-PE.yml
+++ b/messages/pivotgrid/pivotgrid.es-PE.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-PR.yml
+++ b/messages/pivotgrid/pivotgrid.es-PR.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-PY.yml
+++ b/messages/pivotgrid/pivotgrid.es-PY.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-US.yml
+++ b/messages/pivotgrid/pivotgrid.es-US.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-UY.yml
+++ b/messages/pivotgrid/pivotgrid.es-UY.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.es-VE.yml
+++ b/messages/pivotgrid/pivotgrid.es-VE.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.fa-IR.yml
+++ b/messages/pivotgrid/pivotgrid.fa-IR.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.fi-FI.yml
+++ b/messages/pivotgrid/pivotgrid.fi-FI.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.fr-BE.yml
+++ b/messages/pivotgrid/pivotgrid.fr-BE.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-CA.yml
+++ b/messages/pivotgrid/pivotgrid.fr-CA.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-CD.yml
+++ b/messages/pivotgrid/pivotgrid.fr-CD.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-CH.yml
+++ b/messages/pivotgrid/pivotgrid.fr-CH.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-CI.yml
+++ b/messages/pivotgrid/pivotgrid.fr-CI.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-CM.yml
+++ b/messages/pivotgrid/pivotgrid.fr-CM.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-FR.yml
+++ b/messages/pivotgrid/pivotgrid.fr-FR.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-HT.yml
+++ b/messages/pivotgrid/pivotgrid.fr-HT.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-LU.yml
+++ b/messages/pivotgrid/pivotgrid.fr-LU.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-MA.yml
+++ b/messages/pivotgrid/pivotgrid.fr-MA.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-MC.yml
+++ b/messages/pivotgrid/pivotgrid.fr-MC.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-ML.yml
+++ b/messages/pivotgrid/pivotgrid.fr-ML.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.fr-SN.yml
+++ b/messages/pivotgrid/pivotgrid.fr-SN.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtrer
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filtre'
+    filterInputLabel: '[[fields]] Filtre'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Opérateurs de filtre'
+    filterOperatorsDropDownLabel: '[[fields]] Opérateurs de filtre'
 
     # The text of the "equal" filter operator
     filterEqOperator: Est égal à

--- a/messages/pivotgrid/pivotgrid.he-IL.yml
+++ b/messages/pivotgrid/pivotgrid.he-IL.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.hy-AM.yml
+++ b/messages/pivotgrid/pivotgrid.hy-AM.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.it-CH.yml
+++ b/messages/pivotgrid/pivotgrid.it-CH.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.it-IT.yml
+++ b/messages/pivotgrid/pivotgrid.it-IT.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filtro
 
     # The label of the filter input
-    filterInputLabel: 'Filtro {fields}'
+    filterInputLabel: 'Filtro [[fields]]'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: 'Operatori filtro per {fields}'
+    filterOperatorsDropDownLabel: 'Operatori filtro per [[fields]]'
 
     # The text of the "equal" filter operator
     filterEqOperator: È uguale a

--- a/messages/pivotgrid/pivotgrid.ja-JP.yml
+++ b/messages/pivotgrid/pivotgrid.ja-JP.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.ka-GE.yml
+++ b/messages/pivotgrid/pivotgrid.ka-GE.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.nb-NO.yml
+++ b/messages/pivotgrid/pivotgrid.nb-NO.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.nl-BE.yml
+++ b/messages/pivotgrid/pivotgrid.nl-BE.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.nl-NL.yml
+++ b/messages/pivotgrid/pivotgrid.nl-NL.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.pl-PL.yml
+++ b/messages/pivotgrid/pivotgrid.pl-PL.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.pt-BR.yml
+++ b/messages/pivotgrid/pivotgrid.pt-BR.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.pt-PT.yml
+++ b/messages/pivotgrid/pivotgrid.pt-PT.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.ro-RO.yml
+++ b/messages/pivotgrid/pivotgrid.ro-RO.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.ru-RU.yml
+++ b/messages/pivotgrid/pivotgrid.ru-RU.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.sk-SK.yml
+++ b/messages/pivotgrid/pivotgrid.sk-SK.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Je

--- a/messages/pivotgrid/pivotgrid.sv-SE.yml
+++ b/messages/pivotgrid/pivotgrid.sv-SE.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.tr-TR.yml
+++ b/messages/pivotgrid/pivotgrid.tr-TR.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.uk-UA.yml
+++ b/messages/pivotgrid/pivotgrid.uk-UA.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.zh-CN.yml
+++ b/messages/pivotgrid/pivotgrid.zh-CN.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.zh-HK.yml
+++ b/messages/pivotgrid/pivotgrid.zh-HK.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/pivotgrid/pivotgrid.zh-TW.yml
+++ b/messages/pivotgrid/pivotgrid.zh-TW.yml
@@ -7,10 +7,10 @@ kendo:
     fieldMenuFilterItemLabel: Filter
 
     # The label of the filter input
-    filterInputLabel: '{fields} Filter'
+    filterInputLabel: '[[fields]] Filter'
 
     # The label of the filter operators DropDownList
-    filterOperatorsDropDownLabel: '{fields} Filter Operators'
+    filterOperatorsDropDownLabel: '[[fields]] Filter Operators'
 
     # The text of the "equal" filter operator
     filterEqOperator: Is equal to

--- a/messages/scrollview/scrollview.ar.yml
+++ b/messages/scrollview/scrollview.ar.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.bg-BG.yml
+++ b/messages/scrollview/scrollview.bg-BG.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Предмет {itemIndex}'
+    pagerButtonLabel: 'Предмет [[itemIndex]]'

--- a/messages/scrollview/scrollview.cs-CZ.yml
+++ b/messages/scrollview/scrollview.cs-CZ.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.da-DK.yml
+++ b/messages/scrollview/scrollview.da-DK.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.de-AT.yml
+++ b/messages/scrollview/scrollview.de-AT.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Element {itemIndex}'
+    pagerButtonLabel: 'Element [[itemIndex]]'

--- a/messages/scrollview/scrollview.de-CH.yml
+++ b/messages/scrollview/scrollview.de-CH.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Element {itemIndex}'
+    pagerButtonLabel: 'Element [[itemIndex]]'

--- a/messages/scrollview/scrollview.de-DE.yml
+++ b/messages/scrollview/scrollview.de-DE.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Element {itemIndex}'
+    pagerButtonLabel: 'Element [[itemIndex]]'

--- a/messages/scrollview/scrollview.de-LI.yml
+++ b/messages/scrollview/scrollview.de-LI.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.en-AU.yml
+++ b/messages/scrollview/scrollview.en-AU.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.en-CA.yml
+++ b/messages/scrollview/scrollview.en-CA.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.en-GB.yml
+++ b/messages/scrollview/scrollview.en-GB.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.en-US.yml
+++ b/messages/scrollview/scrollview.en-US.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-AR.yml
+++ b/messages/scrollview/scrollview.es-AR.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-BO.yml
+++ b/messages/scrollview/scrollview.es-BO.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-CL.yml
+++ b/messages/scrollview/scrollview.es-CL.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-CO.yml
+++ b/messages/scrollview/scrollview.es-CO.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-CR.yml
+++ b/messages/scrollview/scrollview.es-CR.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-DO.yml
+++ b/messages/scrollview/scrollview.es-DO.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-EC.yml
+++ b/messages/scrollview/scrollview.es-EC.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-ES.yml
+++ b/messages/scrollview/scrollview.es-ES.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-GT.yml
+++ b/messages/scrollview/scrollview.es-GT.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-HN.yml
+++ b/messages/scrollview/scrollview.es-HN.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-MX.yml
+++ b/messages/scrollview/scrollview.es-MX.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-NI.yml
+++ b/messages/scrollview/scrollview.es-NI.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-PA.yml
+++ b/messages/scrollview/scrollview.es-PA.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-PE.yml
+++ b/messages/scrollview/scrollview.es-PE.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-PR.yml
+++ b/messages/scrollview/scrollview.es-PR.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-PY.yml
+++ b/messages/scrollview/scrollview.es-PY.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-US.yml
+++ b/messages/scrollview/scrollview.es-US.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-UY.yml
+++ b/messages/scrollview/scrollview.es-UY.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.es-VE.yml
+++ b/messages/scrollview/scrollview.es-VE.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fa-IR.yml
+++ b/messages/scrollview/scrollview.fa-IR.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fi-FI.yml
+++ b/messages/scrollview/scrollview.fi-FI.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-BE.yml
+++ b/messages/scrollview/scrollview.fr-BE.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-CA.yml
+++ b/messages/scrollview/scrollview.fr-CA.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-CD.yml
+++ b/messages/scrollview/scrollview.fr-CD.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-CH.yml
+++ b/messages/scrollview/scrollview.fr-CH.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-CI.yml
+++ b/messages/scrollview/scrollview.fr-CI.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-CM.yml
+++ b/messages/scrollview/scrollview.fr-CM.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-FR.yml
+++ b/messages/scrollview/scrollview.fr-FR.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-HT.yml
+++ b/messages/scrollview/scrollview.fr-HT.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-LU.yml
+++ b/messages/scrollview/scrollview.fr-LU.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-MA.yml
+++ b/messages/scrollview/scrollview.fr-MA.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-MC.yml
+++ b/messages/scrollview/scrollview.fr-MC.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-ML.yml
+++ b/messages/scrollview/scrollview.fr-ML.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.fr-SN.yml
+++ b/messages/scrollview/scrollview.fr-SN.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.he-IL.yml
+++ b/messages/scrollview/scrollview.he-IL.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.hy-AM.yml
+++ b/messages/scrollview/scrollview.hy-AM.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.it-CH.yml
+++ b/messages/scrollview/scrollview.it-CH.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.it-IT.yml
+++ b/messages/scrollview/scrollview.it-IT.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.ja-JP.yml
+++ b/messages/scrollview/scrollview.ja-JP.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.ka-GE.yml
+++ b/messages/scrollview/scrollview.ka-GE.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.nb-NO.yml
+++ b/messages/scrollview/scrollview.nb-NO.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.nl-BE.yml
+++ b/messages/scrollview/scrollview.nl-BE.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.nl-NL.yml
+++ b/messages/scrollview/scrollview.nl-NL.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.pl-PL.yml
+++ b/messages/scrollview/scrollview.pl-PL.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.pt-BR.yml
+++ b/messages/scrollview/scrollview.pt-BR.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.pt-PT.yml
+++ b/messages/scrollview/scrollview.pt-PT.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.ro-RO.yml
+++ b/messages/scrollview/scrollview.ro-RO.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.ru-RU.yml
+++ b/messages/scrollview/scrollview.ru-RU.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.sk-SK.yml
+++ b/messages/scrollview/scrollview.sk-SK.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.sv-SE.yml
+++ b/messages/scrollview/scrollview.sv-SE.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.tr-TR.yml
+++ b/messages/scrollview/scrollview.tr-TR.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.uk-UA.yml
+++ b/messages/scrollview/scrollview.uk-UA.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.zh-CN.yml
+++ b/messages/scrollview/scrollview.zh-CN.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.zh-HK.yml
+++ b/messages/scrollview/scrollview.zh-HK.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/scrollview/scrollview.zh-TW.yml
+++ b/messages/scrollview/scrollview.zh-TW.yml
@@ -1,4 +1,4 @@
 kendo:
   scrollview:
     # The label for the buttons inside the ScrollView Pager
-    pagerButtonLabel: 'Item {itemIndex}'
+    pagerButtonLabel: 'Item [[itemIndex]]'

--- a/messages/splitbutton/splitbutton.ar.yml
+++ b/messages/splitbutton/splitbutton.ar.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.bg-BG.yml
+++ b/messages/splitbutton/splitbutton.bg-BG.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} бутон'
+    splitButtonLabel: '[[buttonText]] бутон'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Показване/скриване на опциите

--- a/messages/splitbutton/splitbutton.cs-CZ.yml
+++ b/messages/splitbutton/splitbutton.cs-CZ.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.da-DK.yml
+++ b/messages/splitbutton/splitbutton.da-DK.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.de-AT.yml
+++ b/messages/splitbutton/splitbutton.de-AT.yml
@@ -1,7 +1,7 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} geteilter Button'
+    splitButtonLabel: '[[buttonText]] geteilter Button'
 
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.de-CH.yml
+++ b/messages/splitbutton/splitbutton.de-CH.yml
@@ -1,7 +1,7 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} geteilter Button'
+    splitButtonLabel: '[[buttonText]] geteilter Button'
 
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.de-DE.yml
+++ b/messages/splitbutton/splitbutton.de-DE.yml
@@ -1,7 +1,7 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} geteilter Button'
+    splitButtonLabel: '[[buttonText]] geteilter Button'
 
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.de-LI.yml
+++ b/messages/splitbutton/splitbutton.de-LI.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.en-AU.yml
+++ b/messages/splitbutton/splitbutton.en-AU.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.en-CA.yml
+++ b/messages/splitbutton/splitbutton.en-CA.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.en-GB.yml
+++ b/messages/splitbutton/splitbutton.en-GB.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.en-US.yml
+++ b/messages/splitbutton/splitbutton.en-US.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-AR.yml
+++ b/messages/splitbutton/splitbutton.es-AR.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-BO.yml
+++ b/messages/splitbutton/splitbutton.es-BO.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-CL.yml
+++ b/messages/splitbutton/splitbutton.es-CL.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-CO.yml
+++ b/messages/splitbutton/splitbutton.es-CO.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-CR.yml
+++ b/messages/splitbutton/splitbutton.es-CR.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-DO.yml
+++ b/messages/splitbutton/splitbutton.es-DO.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-EC.yml
+++ b/messages/splitbutton/splitbutton.es-EC.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-ES.yml
+++ b/messages/splitbutton/splitbutton.es-ES.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-GT.yml
+++ b/messages/splitbutton/splitbutton.es-GT.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-HN.yml
+++ b/messages/splitbutton/splitbutton.es-HN.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-MX.yml
+++ b/messages/splitbutton/splitbutton.es-MX.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-NI.yml
+++ b/messages/splitbutton/splitbutton.es-NI.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-PA.yml
+++ b/messages/splitbutton/splitbutton.es-PA.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-PE.yml
+++ b/messages/splitbutton/splitbutton.es-PE.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-PR.yml
+++ b/messages/splitbutton/splitbutton.es-PR.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-PY.yml
+++ b/messages/splitbutton/splitbutton.es-PY.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-US.yml
+++ b/messages/splitbutton/splitbutton.es-US.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-UY.yml
+++ b/messages/splitbutton/splitbutton.es-UY.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.es-VE.yml
+++ b/messages/splitbutton/splitbutton.es-VE.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fa-IR.yml
+++ b/messages/splitbutton/splitbutton.fa-IR.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fi-FI.yml
+++ b/messages/splitbutton/splitbutton.fi-FI.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-BE.yml
+++ b/messages/splitbutton/splitbutton.fr-BE.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-CA.yml
+++ b/messages/splitbutton/splitbutton.fr-CA.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-CD.yml
+++ b/messages/splitbutton/splitbutton.fr-CD.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-CH.yml
+++ b/messages/splitbutton/splitbutton.fr-CH.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-CI.yml
+++ b/messages/splitbutton/splitbutton.fr-CI.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-CM.yml
+++ b/messages/splitbutton/splitbutton.fr-CM.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-FR.yml
+++ b/messages/splitbutton/splitbutton.fr-FR.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-HT.yml
+++ b/messages/splitbutton/splitbutton.fr-HT.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-LU.yml
+++ b/messages/splitbutton/splitbutton.fr-LU.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-MA.yml
+++ b/messages/splitbutton/splitbutton.fr-MA.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-MC.yml
+++ b/messages/splitbutton/splitbutton.fr-MC.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-ML.yml
+++ b/messages/splitbutton/splitbutton.fr-ML.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.fr-SN.yml
+++ b/messages/splitbutton/splitbutton.fr-SN.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.he-IL.yml
+++ b/messages/splitbutton/splitbutton.he-IL.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.hy-AM.yml
+++ b/messages/splitbutton/splitbutton.hy-AM.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.it-CH.yml
+++ b/messages/splitbutton/splitbutton.it-CH.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.it-IT.yml
+++ b/messages/splitbutton/splitbutton.it-IT.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.ja-JP.yml
+++ b/messages/splitbutton/splitbutton.ja-JP.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.ka-GE.yml
+++ b/messages/splitbutton/splitbutton.ka-GE.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.nb-NO.yml
+++ b/messages/splitbutton/splitbutton.nb-NO.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.nl-BE.yml
+++ b/messages/splitbutton/splitbutton.nl-BE.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.nl-NL.yml
+++ b/messages/splitbutton/splitbutton.nl-NL.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.pl-PL.yml
+++ b/messages/splitbutton/splitbutton.pl-PL.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.pt-BR.yml
+++ b/messages/splitbutton/splitbutton.pt-BR.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.pt-PT.yml
+++ b/messages/splitbutton/splitbutton.pt-PT.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.ro-RO.yml
+++ b/messages/splitbutton/splitbutton.ro-RO.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.ru-RU.yml
+++ b/messages/splitbutton/splitbutton.ru-RU.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.sk-SK.yml
+++ b/messages/splitbutton/splitbutton.sk-SK.yml
@@ -1,7 +1,7 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} rozdelené tlačidlo'
+    splitButtonLabel: '[[buttonText]] rozdelené tlačidlo'
 
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.sv-SE.yml
+++ b/messages/splitbutton/splitbutton.sv-SE.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.tr-TR.yml
+++ b/messages/splitbutton/splitbutton.tr-TR.yml
@@ -1,7 +1,7 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText}'
+    splitButtonLabel: '[[buttonText]]'
 
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.uk-UA.yml
+++ b/messages/splitbutton/splitbutton.uk-UA.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.zh-CN.yml
+++ b/messages/splitbutton/splitbutton.zh-CN.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.zh-HK.yml
+++ b/messages/splitbutton/splitbutton.zh-HK.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/splitbutton/splitbutton.zh-TW.yml
+++ b/messages/splitbutton/splitbutton.zh-TW.yml
@@ -1,6 +1,6 @@
 kendo:
   splitbutton:
     # The text for the SplitButton aria-label
-    splitButtonLabel: '{buttonText} splitbutton'
+    splitButtonLabel: '[[buttonText]] splitbutton'
     # The text for the SplitButton toggle button aria-label
     toggleButtonLabel: Toggle options

--- a/messages/spreadsheet/spreadsheet.ar.yml
+++ b/messages/spreadsheet/spreadsheet.ar.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.bg-BG.yml
+++ b/messages/spreadsheet/spreadsheet.bg-BG.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Премести надясно
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Невалидно име: {inputValue}'
+    invalidNameError: 'Невалидно име: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Избраният диапазон съдържа недостъпни клетки.

--- a/messages/spreadsheet/spreadsheet.cs-CZ.yml
+++ b/messages/spreadsheet/spreadsheet.cs-CZ.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.da-DK.yml
+++ b/messages/spreadsheet/spreadsheet.da-DK.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.de-AT.yml
+++ b/messages/spreadsheet/spreadsheet.de-AT.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.de-CH.yml
+++ b/messages/spreadsheet/spreadsheet.de-CH.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.de-DE.yml
+++ b/messages/spreadsheet/spreadsheet.de-DE.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.de-LI.yml
+++ b/messages/spreadsheet/spreadsheet.de-LI.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.en-AU.yml
+++ b/messages/spreadsheet/spreadsheet.en-AU.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.en-CA.yml
+++ b/messages/spreadsheet/spreadsheet.en-CA.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.en-GB.yml
+++ b/messages/spreadsheet/spreadsheet.en-GB.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.en-US.yml
+++ b/messages/spreadsheet/spreadsheet.en-US.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-AR.yml
+++ b/messages/spreadsheet/spreadsheet.es-AR.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-BO.yml
+++ b/messages/spreadsheet/spreadsheet.es-BO.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-CL.yml
+++ b/messages/spreadsheet/spreadsheet.es-CL.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-CO.yml
+++ b/messages/spreadsheet/spreadsheet.es-CO.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-CR.yml
+++ b/messages/spreadsheet/spreadsheet.es-CR.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-DO.yml
+++ b/messages/spreadsheet/spreadsheet.es-DO.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-EC.yml
+++ b/messages/spreadsheet/spreadsheet.es-EC.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-ES.yml
+++ b/messages/spreadsheet/spreadsheet.es-ES.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Mover a la derecha
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Nombre inválido: {inputValue}'
+    invalidNameError: 'Nombre inválido: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-GT.yml
+++ b/messages/spreadsheet/spreadsheet.es-GT.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-HN.yml
+++ b/messages/spreadsheet/spreadsheet.es-HN.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-MX.yml
+++ b/messages/spreadsheet/spreadsheet.es-MX.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-NI.yml
+++ b/messages/spreadsheet/spreadsheet.es-NI.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-PA.yml
+++ b/messages/spreadsheet/spreadsheet.es-PA.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-PE.yml
+++ b/messages/spreadsheet/spreadsheet.es-PE.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-PR.yml
+++ b/messages/spreadsheet/spreadsheet.es-PR.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-PY.yml
+++ b/messages/spreadsheet/spreadsheet.es-PY.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-US.yml
+++ b/messages/spreadsheet/spreadsheet.es-US.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-UY.yml
+++ b/messages/spreadsheet/spreadsheet.es-UY.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.es-VE.yml
+++ b/messages/spreadsheet/spreadsheet.es-VE.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fa-IR.yml
+++ b/messages/spreadsheet/spreadsheet.fa-IR.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fi-FI.yml
+++ b/messages/spreadsheet/spreadsheet.fi-FI.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-BE.yml
+++ b/messages/spreadsheet/spreadsheet.fr-BE.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-CA.yml
+++ b/messages/spreadsheet/spreadsheet.fr-CA.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-CD.yml
+++ b/messages/spreadsheet/spreadsheet.fr-CD.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-CH.yml
+++ b/messages/spreadsheet/spreadsheet.fr-CH.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-CI.yml
+++ b/messages/spreadsheet/spreadsheet.fr-CI.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-CM.yml
+++ b/messages/spreadsheet/spreadsheet.fr-CM.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-FR.yml
+++ b/messages/spreadsheet/spreadsheet.fr-FR.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-HT.yml
+++ b/messages/spreadsheet/spreadsheet.fr-HT.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-LU.yml
+++ b/messages/spreadsheet/spreadsheet.fr-LU.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-MA.yml
+++ b/messages/spreadsheet/spreadsheet.fr-MA.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-MC.yml
+++ b/messages/spreadsheet/spreadsheet.fr-MC.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-ML.yml
+++ b/messages/spreadsheet/spreadsheet.fr-ML.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.fr-SN.yml
+++ b/messages/spreadsheet/spreadsheet.fr-SN.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.he-IL.yml
+++ b/messages/spreadsheet/spreadsheet.he-IL.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.hy-AM.yml
+++ b/messages/spreadsheet/spreadsheet.hy-AM.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.it-CH.yml
+++ b/messages/spreadsheet/spreadsheet.it-CH.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.it-IT.yml
+++ b/messages/spreadsheet/spreadsheet.it-IT.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.ja-JP.yml
+++ b/messages/spreadsheet/spreadsheet.ja-JP.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.ka-GE.yml
+++ b/messages/spreadsheet/spreadsheet.ka-GE.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.nb-NO.yml
+++ b/messages/spreadsheet/spreadsheet.nb-NO.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.nl-BE.yml
+++ b/messages/spreadsheet/spreadsheet.nl-BE.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.nl-NL.yml
+++ b/messages/spreadsheet/spreadsheet.nl-NL.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.pl-PL.yml
+++ b/messages/spreadsheet/spreadsheet.pl-PL.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.pt-BR.yml
+++ b/messages/spreadsheet/spreadsheet.pt-BR.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.pt-PT.yml
+++ b/messages/spreadsheet/spreadsheet.pt-PT.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.ro-RO.yml
+++ b/messages/spreadsheet/spreadsheet.ro-RO.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.ru-RU.yml
+++ b/messages/spreadsheet/spreadsheet.ru-RU.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.sk-SK.yml
+++ b/messages/spreadsheet/spreadsheet.sk-SK.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.sv-SE.yml
+++ b/messages/spreadsheet/spreadsheet.sv-SE.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.tr-TR.yml
+++ b/messages/spreadsheet/spreadsheet.tr-TR.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.uk-UA.yml
+++ b/messages/spreadsheet/spreadsheet.uk-UA.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.zh-CN.yml
+++ b/messages/spreadsheet/spreadsheet.zh-CN.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.zh-HK.yml
+++ b/messages/spreadsheet/spreadsheet.zh-HK.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/spreadsheet/spreadsheet.zh-TW.yml
+++ b/messages/spreadsheet/spreadsheet.zh-TW.yml
@@ -226,7 +226,7 @@ kendo:
     sheetMoveRight: Move Right
 
     # The content of the dialog that warns about invalid name input
-    invalidNameError: 'Invalid name: {inputValue}'
+    invalidNameError: 'Invalid name: [[inputValue]]'
 
     # The content of the dialog that warns about performing an action on a range that contains disabled cells.
     rangeDisabled: Destination range contains disabled cells.

--- a/messages/treelist/treelist.ar.yml
+++ b/messages/treelist/treelist.ar.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.bg-BG.yml
+++ b/messages/treelist/treelist.bg-BG.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Сортирай
 
     # The title of the column menu icon
-    columnMenu: 'Меню за настройки на колоната {columnName}'
+    columnMenu: 'Меню за настройки на колоната [[columnName]]'
 
     # The text shown in the column menu for the columns item
     columns: Колони
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Влачене на ред
 
     # The label for the TreeList pager
-    pagerLabel: 'Навигация, страница {currentPage} от {totalPages}'
+    pagerLabel: 'Навигация, страница [[currentPage]] от [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Избери всички редове
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Филтър оператори за {columnName}'
+    filterCellOperatorLabel: 'Филтър оператори за [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Булев филтър за {columnName}'
+    booleanFilterCellLabel: 'Булев филтър за [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Въведи номер на страница
     
     # The label of the filter row and menu inputs
-    filterInputLabel: 'Филтър за {columnName}'
+    filterInputLabel: 'Филтър за [[columnName]]'
 
     # The title of the filter menu icon
-    filterMenuTitle: 'Меню за филтриране на {columnName}'
+    filterMenuTitle: 'Меню за филтриране на [[columnName]]'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Днес
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Увеличи стойността
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: 'Оператори за филтриране на {columnName}'
+    filterMenuOperatorsDropDownLabel: 'Оператори за филтриране на [[columnName]]'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: 'Логика за филтриране на {columnName}'
+    filterMenuLogicDropDownLabel: 'Логика за филтриране на [[columnName]]'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Оразмери тази колона

--- a/messages/treelist/treelist.cs-CZ.yml
+++ b/messages/treelist/treelist.cs-CZ.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.da-DK.yml
+++ b/messages/treelist/treelist.da-DK.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.de-AT.yml
+++ b/messages/treelist/treelist.de-AT.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sortieren
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Spaltenmenü'
+    columnMenu: '[[columnName]] Spaltenmenü'
 
     # The text shown in the column menu for the columns item
     columns: Spalten
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Zeile ziehen
 
     # The label for the TreeList pager
-    pagerLabel: 'Zeilennavigation, Seite {currentPage} von {totalPages}'
+    pagerLabel: 'Zeilennavigation, Seite [[currentPage]] von [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Obere Toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Alle Zeilen auswählen
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filterzelle Operatoren für {columnName}'
+    filterCellOperatorLabel: 'Filterzelle Operatoren für [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolesche Filterzelle für {columnName}'
+    booleanFilterCellLabel: 'Boolesche Filterzelle für [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.de-CH.yml
+++ b/messages/treelist/treelist.de-CH.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sortieren
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Spaltenmenü'
+    columnMenu: '[[columnName]] Spaltenmenü'
 
     # The text shown in the column menu for the columns item
     columns: Spalten
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Zeile ziehen
 
     # The label for the TreeList pager
-    pagerLabel: 'Zeilennavigation, Seite {currentPage} von {totalPages}'
+    pagerLabel: 'Zeilennavigation, Seite [[currentPage]] von [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Obere Toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Alle Zeilen auswählen
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filterzelle Operatoren für {columnName}'
+    filterCellOperatorLabel: 'Filterzelle Operatoren für [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolesche Filterzelle für {columnName}'
+    booleanFilterCellLabel: 'Boolesche Filterzelle für [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.de-DE.yml
+++ b/messages/treelist/treelist.de-DE.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sortieren
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Spaltenmenü'
+    columnMenu: '[[columnName]] Spaltenmenü'
 
     # The text shown in the column menu for the columns item
     columns: Spalten
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Zeile ziehen
 
     # The label for the TreeList pager
-    pagerLabel: 'Zeilennavigation, Seite {currentPage} von {totalPages}'
+    pagerLabel: 'Zeilennavigation, Seite [[currentPage]] von [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Obere Toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Alle Zeilen auswählen
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filterzelle Operatoren für {columnName}'
+    filterCellOperatorLabel: 'Filterzelle Operatoren für [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolesche Filterzelle für {columnName}'
+    booleanFilterCellLabel: 'Boolesche Filterzelle für [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.de-LI.yml
+++ b/messages/treelist/treelist.de-LI.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sortieren
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Spaltenmenü'
+    columnMenu: '[[columnName]] Spaltenmenü'
 
     # The text shown in the column menu for the columns item
     columns: Spalten
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
     
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Heute
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.en-AU.yml
+++ b/messages/treelist/treelist.en-AU.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.en-CA.yml
+++ b/messages/treelist/treelist.en-CA.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.en-GB.yml
+++ b/messages/treelist/treelist.en-GB.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.en-US.yml
+++ b/messages/treelist/treelist.en-US.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-AR.yml
+++ b/messages/treelist/treelist.es-AR.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-BO.yml
+++ b/messages/treelist/treelist.es-BO.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-CL.yml
+++ b/messages/treelist/treelist.es-CL.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-CO.yml
+++ b/messages/treelist/treelist.es-CO.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-CR.yml
+++ b/messages/treelist/treelist.es-CR.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-DO.yml
+++ b/messages/treelist/treelist.es-DO.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-EC.yml
+++ b/messages/treelist/treelist.es-EC.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-ES.yml
+++ b/messages/treelist/treelist.es-ES.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Ordenar
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menú de Columna'
+    columnMenu: '[[columnName]] Menú de Columna'
 
     # The text shown in the column menu for the columns item
     columns: Columnas
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Arrastrar fila
 
     # The label for the TreeList pager
-    pagerLabel: 'Navegación de página, página {currentPage} de {totalPages}'
+    pagerLabel: 'Navegación de página, página [[currentPage]] de [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Barra de herramientas superior
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Seleccionar todas las filas
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Operadores de filtro de celda para {columnName}'
+    filterCellOperatorLabel: 'Operadores de filtro de celda para [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Filtro booleano de celda para {columnName}'
+    booleanFilterCellLabel: 'Filtro booleano de celda para [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-GT.yml
+++ b/messages/treelist/treelist.es-GT.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-HN.yml
+++ b/messages/treelist/treelist.es-HN.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-MX.yml
+++ b/messages/treelist/treelist.es-MX.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-NI.yml
+++ b/messages/treelist/treelist.es-NI.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-PA.yml
+++ b/messages/treelist/treelist.es-PA.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-PE.yml
+++ b/messages/treelist/treelist.es-PE.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
     
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-PR.yml
+++ b/messages/treelist/treelist.es-PR.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-PY.yml
+++ b/messages/treelist/treelist.es-PY.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-US.yml
+++ b/messages/treelist/treelist.es-US.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-UY.yml
+++ b/messages/treelist/treelist.es-UY.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.es-VE.yml
+++ b/messages/treelist/treelist.es-VE.yml
@@ -112,7 +112,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -154,7 +154,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -169,19 +169,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -196,10 +196,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fa-IR.yml
+++ b/messages/treelist/treelist.fa-IR.yml
@@ -115,7 +115,7 @@ kendo:
     sort: مرتب‌سازی
 
     # The title of the column menu icon
-    columnMenu: 'فهرست انتخاب ستون {columnName}'
+    columnMenu: 'فهرست انتخاب ستون [[columnName]]'
 
     # The text shown in the column menu for the columns item
     columns: ستون‌ها
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fi-FI.yml
+++ b/messages/treelist/treelist.fi-FI.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-BE.yml
+++ b/messages/treelist/treelist.fr-BE.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-CA.yml
+++ b/messages/treelist/treelist.fr-CA.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-CD.yml
+++ b/messages/treelist/treelist.fr-CD.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-CH.yml
+++ b/messages/treelist/treelist.fr-CH.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-CI.yml
+++ b/messages/treelist/treelist.fr-CI.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-CM.yml
+++ b/messages/treelist/treelist.fr-CM.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-FR.yml
+++ b/messages/treelist/treelist.fr-FR.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-HT.yml
+++ b/messages/treelist/treelist.fr-HT.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-LU.yml
+++ b/messages/treelist/treelist.fr-LU.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-MA.yml
+++ b/messages/treelist/treelist.fr-MA.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-MC.yml
+++ b/messages/treelist/treelist.fr-MC.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-ML.yml
+++ b/messages/treelist/treelist.fr-ML.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.fr-SN.yml
+++ b/messages/treelist/treelist.fr-SN.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Tri
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Menu des colonnes'
+    columnMenu: '[[columnName]] Menu des colonnes'
 
     # The text shown in the column menu for the columns item
     columns: Colonnes
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.he-IL.yml
+++ b/messages/treelist/treelist.he-IL.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.hy-AM.yml
+++ b/messages/treelist/treelist.hy-AM.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.it-CH.yml
+++ b/messages/treelist/treelist.it-CH.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Ordina
 
     # The title of the column menu icon
-    columnMenu: 'Menù colonna {columnName}'
+    columnMenu: 'Menù colonna [[columnName]]'
 
     # The text shown in the column menu for the columns item
     columns: Colonne
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.it-IT.yml
+++ b/messages/treelist/treelist.it-IT.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Ordina
 
     # The title of the column menu icon
-    columnMenu: 'Menù colonna {columnName}'
+    columnMenu: 'Menù colonna [[columnName]]'
 
     # The text shown in the column menu for the columns item
     columns: Colonne
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.ja-JP.yml
+++ b/messages/treelist/treelist.ja-JP.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.ka-GE.yml
+++ b/messages/treelist/treelist.ka-GE.yml
@@ -115,7 +115,7 @@ kendo:
     sort: დალაგება
 
     # The title of the column menu icon
-    columnMenu: '{columnName} მენიუ'
+    columnMenu: '[[columnName]] მენიუ'
 
     # The text shown in the column menu for the columns item
     columns: სვეტები
@@ -155,7 +155,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -170,19 +170,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -197,10 +197,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.nb-NO.yml
+++ b/messages/treelist/treelist.nb-NO.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.nl-BE.yml
+++ b/messages/treelist/treelist.nl-BE.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sorteren
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.nl-NL.yml
+++ b/messages/treelist/treelist.nl-NL.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sorteren
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.pl-PL.yml
+++ b/messages/treelist/treelist.pl-PL.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.pt-BR.yml
+++ b/messages/treelist/treelist.pt-BR.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.pt-PT.yml
+++ b/messages/treelist/treelist.pt-PT.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.ro-RO.yml
+++ b/messages/treelist/treelist.ro-RO.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.ru-RU.yml
+++ b/messages/treelist/treelist.ru-RU.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Сортировать
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Меню колонки'
+    columnMenu: '[[columnName]] Меню колонки'
 
     # The text shown in the column menu for the columns item
     columns: Колонки
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.sk-SK.yml
+++ b/messages/treelist/treelist.sk-SK.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: 'Menu stĺpca {columnName}'
+    columnMenu: 'Menu stĺpca [[columnName]]'
 
     # The text shown in the column menu for the columns item
     columns: Stĺpce
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.sv-SE.yml
+++ b/messages/treelist/treelist.sv-SE.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sortera
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Kolumnmeny'
+    columnMenu: '[[columnName]] Kolumnmeny'
 
     # The text shown in the column menu for the columns item
     columns: Kolumner
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.tr-TR.yml
+++ b/messages/treelist/treelist.tr-TR.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.uk-UA.yml
+++ b/messages/treelist/treelist.uk-UA.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.zh-CN.yml
+++ b/messages/treelist/treelist.zh-CN.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.zh-HK.yml
+++ b/messages/treelist/treelist.zh-HK.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column

--- a/messages/treelist/treelist.zh-TW.yml
+++ b/messages/treelist/treelist.zh-TW.yml
@@ -115,7 +115,7 @@ kendo:
     sort: Sort
 
     # The title of the column menu icon
-    columnMenu: '{columnName} Column Menu'
+    columnMenu: '[[columnName]] Column Menu'
 
     # The text shown in the column menu for the columns item
     columns: Columns
@@ -157,7 +157,7 @@ kendo:
     dragRowHandleLabel: Drag row
 
     # The label for the TreeList pager
-    pagerLabel: 'Page navigation, page {currentPage} of {totalPages}'
+    pagerLabel: 'Page navigation, page [[currentPage]] of [[totalPages]]'
 
     # The label for the TreeList top toolbar
     topToolbarLabel: Top toolbar
@@ -172,19 +172,19 @@ kendo:
     selectAllRowsCheckboxLabel: Select all rows
 
     # The label for the filter cell operators dropdown.
-    filterCellOperatorLabel: 'Filter cell operators for {columnName}'
+    filterCellOperatorLabel: 'Filter cell operators for [[columnName]]'
 
     # The label for the boolean filter cell dropdown.
-    booleanFilterCellLabel: 'Boolean filter cell for {columnName}'
+    booleanFilterCellLabel: 'Boolean filter cell for [[columnName]]'
 
     # The text of the aria-label attribute applied to the input element for entering the page number
     pagerInputLabel: Type a page number
     
     # The label of the filter row and menu inputs
-    filterInputLabel: '{columnName} Filter'
+    filterInputLabel: '[[columnName]] Filter'
 
     # The title of the filter menu icon
-    filterMenuTitle: '{columnName} Filter Menu'
+    filterMenuTitle: '[[columnName]] Filter Menu'
 
     # The text of the Today button of the Date filter.
     filterDateToday: Today
@@ -199,10 +199,10 @@ kendo:
     filterNumericIncrement: Increase value
 
     # The label of the filter menu operators dropdown
-    filterMenuOperatorsDropDownLabel: '{columnName} Filter Operators'
+    filterMenuOperatorsDropDownLabel: '[[columnName]] Filter Operators'
 
     # The label of the filter menu logic dropdown
-    filterMenuLogicDropDownLabel: '{columnName} Filter Logic'
+    filterMenuLogicDropDownLabel: '[[columnName]] Filter Logic'
 
     # The text shown in the column menu for the autosize this column item
     autosizeThisColumn: Autosize This Column


### PR DESCRIPTION
Related to https://github.com/telerik/kendo-angular/issues/4089

### Problem
Messages with dynamic placeholders (e.g., `{columnName} Filter`) were resolving to empty strings at runtime when [using the Angular i18n Framework](https://www.telerik.com/kendo-angular-ui/components/globalization/localization/messages#using-the-angular-i18n-framework) for translation.

Root cause: Angular's i18n system uses `{…}` syntax for ICU conditional/plural expressions. When the compiler encounters a simple `{columnName}` placeholder, it attempts to parse it as an ICU expression. When this fails, the message content is discarded, resulting in empty output.

### Solution
Updated all affected messages to use `[[placeholder]]` syntax instead of `{placeholder}`. Double square brackets have no special meaning in Angular's i18n pipeline or ICU format, so they pass through untouched by all parsers and translators.

**Existing translations are preserved:** If you have existing translations with the old `{name}` syntax, they continue to work. The Kendo UI for Angular components support both old `{name}` and new `[[name]]` placeholder formats at runtime for backwards compatibility.