### PR TITLE
chore(ci): add protected environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on: workflow_dispatch
 jobs:
   build:
     runs-on: ubuntu-24.04
+    environment: production
 
     permissions:
         id-token: write # Required by Akeyless
@@ -18,7 +19,7 @@ jobs:
     steps:
       - name: Import Secrets
         id: import-secrets
-        uses: LanceMcCarthy/akeyless-action@v3
+        uses: LanceMcCarthy/akeyless-action@v5
         with:
           access-id: ${{ secrets.GH_AKEYLESS_ACCESS_ID }}
           static-secrets: '{ "/WebComponents/prod/tokens/GH_TOKEN": "GH_TOKEN" }'


### PR DESCRIPTION
Add ref to `production` environment, to implement deployment protection. 